### PR TITLE
Upgrade Elixir v1.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,8 @@ name: "Tests"
 on: pull_request
 
 env:
-  OTP_VERSION: 23.0.2
-  ELIXIR_VERSION: 1.10.4
+  OTP_VERSION: 23.1.1
+  ELIXIR_VERSION: 1.11.0
   PHOENIX_VERSION: 1.5.5
 
 jobs:

--- a/.github/workflows/test_variant.yml
+++ b/.github/workflows/test_variant.yml
@@ -3,8 +3,8 @@ name: "Test variants"
 on: pull_request
 
 env:
-  OTP_VERSION: 23.0.2
-  ELIXIR_VERSION: 1.10.4
+  OTP_VERSION: 23.1.1
+  ELIXIR_VERSION: 1.11.0
   PHOENIX_VERSION: 1.5.5
   NODE_VERSION: 12
   PROJECT_DIRECTORY: "sample_project"

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 23.1.1
+elixir 1.11.0-otp-23

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule NimblePhxGenTemplate.MixProject do
     [
       app: :nimble_phx_gen_template,
       version: "0.1.0",
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## What happened

Upgrade to Elixir 1.11
 
## Insight

- Update the Elixir version in `mix.exs`
- Update the Elixir version on Github action
- Adding [.tool-versions](https://asdf-vm.com/#/core-configuration?id=tool-versions) to set the local Erlang and Elixir version on the developer's local
 
## Proof Of Work

The test should be passed without any warning
