### PR TITLE
Updating credo addon

### DIFF
--- a/lib/nimble.phx.gen.template/addons/credo.ex
+++ b/lib/nimble.phx.gen.template/addons/credo.ex
@@ -35,7 +35,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.Credo do
             codebase: ["format --check-formatted"],
       """,
       """
-            codebase: ["format --check-formatted", "credo"],
+            codebase: ["format --check-formatted", "credo --strict"],
       """
     )
 

--- a/lib/nimble.phx.gen.template/addons/test_env.ex
+++ b/lib/nimble.phx.gen.template/addons/test_env.ex
@@ -40,14 +40,16 @@ defmodule Nimble.Phx.Gen.Template.Addons.TestEnv do
 
   defp edit_test_support_cases(project) do
     project
-    |> edit_test_support_case("test/support/channel_case.ex")
-    |> edit_test_support_case("test/support/conn_case.ex")
-    |> edit_test_support_case("test/support/data_case.ex")
+    |> edit_test_support_case("channel_case")
+    |> edit_test_support_case("conn_case")
+    |> edit_test_support_case("data_case")
   end
 
-  defp edit_test_support_case(project, case_path) do
+  defp edit_test_support_case(project, support_case_name) do
+    support_case_path = "test/support/" <> support_case_name <> ".ex"
+
     Generator.inject_content(
-      case_path,
+      support_case_path,
       """
         use ExUnit.CaseTemplate
       """,
@@ -58,7 +60,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.TestEnv do
     )
 
     Generator.replace_content(
-      case_path,
+      support_case_path,
       """
           :ok = Ecto.Adapters.SQL.Sandbox.checkout(#{project.base_module}.Repo)
       """,
@@ -68,7 +70,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.TestEnv do
     )
 
     Generator.replace_content(
-      case_path,
+      support_case_path,
       """
         Ecto.Adapters.SQL.Sandbox.mode(#{project.base_module}.Repo, {:shared, self()})
       """,

--- a/lib/nimble.phx.gen.template/addons/test_env.ex
+++ b/lib/nimble.phx.gen.template/addons/test_env.ex
@@ -6,6 +6,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.TestEnv do
     project
     |> edit_mix()
     |> edit_test_config()
+    |> edit_test_support_cases()
   end
 
   defp edit_mix(project) do
@@ -31,6 +32,48 @@ defmodule Nimble.Phx.Gen.Template.Addons.TestEnv do
       """,
       """
         hostname: System.get_env("DB_HOST") || "localhost",
+      """
+    )
+
+    project
+  end
+
+  defp edit_test_support_cases(project) do
+    project
+    |> edit_test_support_case("test/support/channel_case.ex")
+    |> edit_test_support_case("test/support/conn_case.ex")
+    |> edit_test_support_case("test/support/data_case.ex")
+  end
+
+  defp edit_test_support_case(project, case_path) do
+    Generator.inject_content(
+      case_path,
+      """
+        use ExUnit.CaseTemplate
+      """,
+      """
+
+        alias Ecto.Adapters.SQL.Sandbox
+      """
+    )
+
+    Generator.replace_content(
+      case_path,
+      """
+          :ok = Ecto.Adapters.SQL.Sandbox.checkout(#{project.base_module}.Repo)
+      """,
+      """
+          :ok = Sandbox.checkout(#{project.base_module}.Repo)
+      """
+    )
+
+    Generator.replace_content(
+      case_path,
+      """
+        Ecto.Adapters.SQL.Sandbox.mode(#{project.base_module}.Repo, {:shared, self()})
+      """,
+      """
+        Sandbox.mode(#{project.base_module}.Repo, {:shared, self()})
       """
     )
 

--- a/lib/nimble.phx.gen.template/addons/variants/web/sobelow.ex
+++ b/lib/nimble.phx.gen.template/addons/variants/web/sobelow.ex
@@ -32,10 +32,10 @@ defmodule Nimble.Phx.Gen.Template.Addons.Web.Sobelow do
     Generator.replace_content(
       "mix.exs",
       """
-            codebase: ["format --check-formatted", "credo"],
+            codebase: ["format --check-formatted", "credo --strict"],
       """,
       """
-            codebase: ["format --check-formatted", "credo", "sobelow --config"],
+            codebase: ["format --check-formatted", "credo --strict", "sobelow --config"],
       """
     )
 

--- a/priv/templates/nimble.phx.gen.template/.credo.exs
+++ b/priv/templates/nimble.phx.gen.template/.credo.exs
@@ -21,7 +21,16 @@
         # You can give explicit globs or simply directories.
         # In the latter case `**/*.{ex,exs}` will be used.
         #
-        included: ["lib/", "src/", "test/", "web/"],
+        included: [
+          "lib/",
+          "src/",
+          "test/",
+          "web/",
+          "apps/*/lib/",
+          "apps/*/src/",
+          "apps/*/test/",
+          "apps/*/web/"
+        ],
         excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
       },
       #
@@ -72,7 +81,8 @@
         # You can customize the priority of any check
         # Priority values are: `low, normal, high, higher`
         #
-        {Credo.Check.Design.AliasUsage, false},
+        {Credo.Check.Design.AliasUsage,
+         [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
         # You can also customize the exit_status of each check.
         # If you don't want TODO comments to cause `mix credo` to fail, just
         # set this value to 0 (zero).
@@ -146,25 +156,25 @@
         #
         # Controversial and experimental checks (opt-in, just replace `false` with `[]`)
         #
-        {Credo.Check.Readability.StrictModuleLayout, false},
-        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
+        {Credo.Check.Readability.StrictModuleLayout, []},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
         {Credo.Check.Consistency.UnusedVariableNames, false},
-        {Credo.Check.Design.DuplicatedCode, false},
+        {Credo.Check.Design.DuplicatedCode, []},
         {Credo.Check.Readability.AliasAs, false},
         {Credo.Check.Readability.MultiAlias, false},
         {Credo.Check.Readability.Specs, false},
-        {Credo.Check.Readability.SinglePipe, false},
-        {Credo.Check.Readability.WithCustomTaggedTuple, false},
-        {Credo.Check.Refactor.ABCSize, false},
-        {Credo.Check.Refactor.AppendSingleItem, false},
-        {Credo.Check.Refactor.DoubleBooleanNegation, false},
+        {Credo.Check.Readability.SinglePipe, []},
+        {Credo.Check.Readability.WithCustomTaggedTuple, []},
+        {Credo.Check.Refactor.ABCSize, []},
+        {Credo.Check.Refactor.AppendSingleItem, []},
+        {Credo.Check.Refactor.DoubleBooleanNegation, []},
         {Credo.Check.Refactor.ModuleDependencies, false},
-        {Credo.Check.Refactor.NegatedIsNil, false},
-        {Credo.Check.Refactor.PipeChainStart, false},
-        {Credo.Check.Refactor.VariableRebinding, false},
-        {Credo.Check.Warning.LeakyEnvironment, false},
-        {Credo.Check.Warning.MapGetUnsafePass, false},
-        {Credo.Check.Warning.UnsafeToAtom, false}
+        {Credo.Check.Refactor.NegatedIsNil, []},
+        {Credo.Check.Refactor.PipeChainStart, []},
+        {Credo.Check.Refactor.VariableRebinding, []},
+        {Credo.Check.Warning.LeakyEnvironment, []},
+        {Credo.Check.Warning.MapGetUnsafePass, []},
+        {Credo.Check.Warning.UnsafeToAtom, []}
 
         #
         # Custom checks can be created using `mix credo.gen.check`.

--- a/priv/templates/nimble.phx.gen.template/test/features/home_page/view_home_page_test.exs.eex
+++ b/priv/templates/nimble.phx.gen.template/test/features/home_page/view_home_page_test.exs.eex
@@ -2,10 +2,8 @@ defmodule <%= web_module %>.HomePage.ViewHomePageTest do
   use <%= web_module %>.FeatureCase
 
   feature "view home page", %{session: session} do
-    session
-    |> visit(Routes.page_path(<%= web_module %>.Endpoint, :index))
+    visit(session, Routes.page_path(AnModuleWeb.Endpoint, :index))
 
-    session
-    |> assert_has(Query.text("Welcome to Phoenix!"))
+    assert_has(session, Query.text("Welcome to Phoenix!"))
   end
 end

--- a/test/nimble.phx.gen.template/addons/credo_test.exs
+++ b/test/nimble.phx.gen.template/addons/credo_test.exs
@@ -41,7 +41,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.CredoTest do
           assert file =~ """
                    defp aliases do
                      [
-                       codebase: [\"format --check-formatted\", \"credo\"],
+                       codebase: [\"format --check-formatted\", \"credo --strict\"],
                  """
         end)
       end)

--- a/test/nimble.phx.gen.template/addons/test_env_test.exs
+++ b/test/nimble.phx.gen.template/addons/test_env_test.exs
@@ -25,5 +25,22 @@ defmodule Nimble.Phx.Gen.Template.Addons.TestEnvTest do
         end)
       end)
     end
+
+    test "creates alias Ecto.Adapters.SQL.Sandbox in test support case", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        Addons.TestEnv.apply(project)
+
+        Enum.each(["channel_case", "conn_case", "data_case"], fn support_case_name ->
+          assert_file("test/support/" <> support_case_name <> ".ex", fn file ->
+            assert file =~ "alias Ecto.Adapters.SQL.Sandbox"
+            assert file =~ "Sandbox.checkout(#{project.base_module}.Repo)"
+            assert file =~ "Sandbox.mode(#{project.base_module}.Repo, {:shared, self()})"
+          end)
+        end)
+      end)
+    end
   end
 end

--- a/test/nimble.phx.gen.template/addons/variants/web/sobelow_test.exs
+++ b/test/nimble.phx.gen.template/addons/variants/web/sobelow_test.exs
@@ -41,7 +41,7 @@ defmodule Nimble.Phx.Gen.Template.AddonsWeb.SobelowTest do
           assert file =~ """
                    defp aliases do
                      [
-                       codebase: [\"format --check-formatted\", \"credo\", \"sobelow --config\"],
+                       codebase: [\"format --check-formatted\", \"credo --strict\", \"sobelow --config\"],
                  """
         end)
       end)


### PR DESCRIPTION
## What happened

Relative to https://github.com/nimblehq/elixir-templates/issues/4

First of all, I think it's better to use `credo --strict` mode, at least when we create a new project, after that each project could decide to remove that or not. Using the `credo --strict` mode can ensure we have good quality code.

Secondary, I update the `.credo.exs` file to the same as the original .credo.exs, as the base template should stick with the default .credo rule as much as possible, because we just generate a new project, later on, each project could custom if needed
 
## Insight

- Adding `credo --strict` mode
- Update the `.credo.exs`
- Adding the `alias Ecto.Adapters.SQL.Sandbox` following Credo suggestion
 
## Proof Of Work

The test is passed.
