### PR TITLE
Updating Github action composite version

### DIFF
--- a/.github/workflows/test_api_variant_on_custom_api_project.yml
+++ b/.github/workflows/test_api_variant_on_custom_api_project.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-
               
-      - uses: nimblehq/elixir-templates@feature/releases
+      - uses: nimblehq/elixir-templates@composite_1.0
         with:
           new_project_options: '--no-html --no-webpack --module=CustomModule --app=custom_app'
           variant: 'api'

--- a/.github/workflows/test_api_variant_on_standard_api_project.yml
+++ b/.github/workflows/test_api_variant_on_standard_api_project.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-
               
-      - uses: nimblehq/elixir-templates@feature/releases
+      - uses: nimblehq/elixir-templates@composite_1.0
         with:
           new_project_options: '--no-html --no-webpack'
           variant: 'api'

--- a/.github/workflows/test_variant_on_custom_project.yml
+++ b/.github/workflows/test_variant_on_custom_project.yml
@@ -67,7 +67,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-packages-
               
-      - uses: nimblehq/elixir-templates@feature/releases
+      - uses: nimblehq/elixir-templates@composite_1.0
         with:
           new_project_options: '--module=CustomModule --app=custom_app'
           variant: ${{ matrix.variant }}

--- a/.github/workflows/test_variant_on_standard_project.yml
+++ b/.github/workflows/test_variant_on_standard_project.yml
@@ -67,7 +67,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-packages-
               
-      - uses: nimblehq/elixir-templates@feature/releases
+      - uses: nimblehq/elixir-templates@composite_1.0
         with:
           new_project_options: ''
           variant: ${{ matrix.variant }}


### PR DESCRIPTION
## What happened

Due to the limitation of the Github composite version, it requires a specific git ref, either branch name, tag, version, we need to make a release for only `composite` and using it.
 
## Insight

The config was set as `feature/releases` branch but as we merge that PR already so the branch is no longer stable as someone could delete it, so instead of using the `branch` name, we could use the tag (for only composite) so it's not confused with the `main template release tag`

Moving on, in the future, if we have some change in the `action.yml` file, we could do another release for `composite_2.x` for example.

[Tags](https://github.com/nimblehq/elixir-templates/tags)

![image](https://user-images.githubusercontent.com/11751745/96852591-8172fc80-1483-11eb-8b68-f80030f6f847.png)

 
## Proof Of Work

The test is passed
