### PR TITLE
Adding test/factories to elixirrc path

### DIFF
--- a/lib/nimble.phx.gen.template/addons/ex_machina.ex
+++ b/lib/nimble.phx.gen.template/addons/ex_machina.ex
@@ -19,6 +19,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.ExMachina do
   defp edit_files(%Project{} = project) do
     project
     |> inject_mix_dependency()
+    |> edit_mix_elixirc_paths()
     |> edit_test_helper()
     |> import_factory()
 
@@ -27,6 +28,20 @@ defmodule Nimble.Phx.Gen.Template.Addons.ExMachina do
 
   defp inject_mix_dependency(%Project{} = project) do
     Generator.inject_mix_dependency({:ex_machina, latest_package_version(:ex_machina), only: :test})
+
+    project
+  end
+
+  def edit_mix_elixirc_paths(%Project{} = project) do
+    Generator.replace_content(
+      "mix.exs",
+      """
+      defp elixirc_paths(:test), do: ["lib", "test/support"]
+      """,
+      """
+      defp elixirc_paths(:test), do: ["lib", "test/support", "test/factories"]
+      """
+    )
 
     project
   end

--- a/priv/templates/nimble.phx.gen.template/test/support/factory.ex.eex
+++ b/priv/templates/nimble.phx.gen.template/test/support/factory.ex.eex
@@ -1,5 +1,6 @@
 defmodule <%= base_module %>.Factory do
   use ExMachina.Ecto, repo: <%= base_module %>.Repo
 
-  # Define your factories in /test/factories and declare it here, eg: `use <%= base_module %>.Accounts.UserFactory`
+  # Define your factories in /test/factories and declare it here,
+  # eg: `use <%base_module %>.Accounts.UserFactory`
 end

--- a/priv/templates/nimble.phx.gen.template/test/support/factory.ex.eex
+++ b/priv/templates/nimble.phx.gen.template/test/support/factory.ex.eex
@@ -1,10 +1,5 @@
 defmodule <%= base_module %>.Factory do
   use ExMachina.Ecto, repo: <%= base_module %>.Repo
 
-  # Define your factories
-  # def user_factory do
-  #   %User{
-  #     email: sequence(:email, &"test-#{&1}@example.com")
-  #   }
-  # end
+  # Define your factories in /test/factories and declare it here, eg: `use <%= base_module %>.Accounts.UserFactory`
 end

--- a/test/nimble.phx.gen.template/addons/ex_machina_test.exs
+++ b/test/nimble.phx.gen.template/addons/ex_machina_test.exs
@@ -32,6 +32,21 @@ defmodule Nimble.Phx.Gen.Template.Addons.ExMachinaTest do
       end)
     end
 
+    test "adds test/factories to elixirc_paths", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        Addons.ExMachina.apply(project)
+
+        assert_file("mix.exs", fn file ->
+          assert file =~ """
+                 defp elixirc_paths(:test), do: ["lib", "test/support", "test/factories"]
+                 """
+        end)
+      end)
+    end
+
     test "updates test/test_helper.exs", %{project: project, test_project_path: test_project_path} do
       in_test_project(test_project_path, fn ->
         Addons.ExMachina.apply(project)

--- a/test/nimble.phx.gen.template/addons/ex_machina_test.exs
+++ b/test/nimble.phx.gen.template/addons/ex_machina_test.exs
@@ -32,7 +32,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.ExMachinaTest do
       end)
     end
 
-    test "adds test/factories to elixirc_paths", %{
+    test "adds test/factories into elixirc_paths", %{
       project: project,
       test_project_path: test_project_path
     } do


### PR DESCRIPTION
## What happened

Adding `test/factories` to defp elixirc_paths(:test)
 
## Insight

- The factories is in the test/factories folder, so we need to add the `test/factories` to the `elixirc_paths(:test)` following guide on https://github.com/thoughtbot/ex_machina#using-with-phoenix
 
## Proof Of Work

The test is passed
