### PR TITLE
Set line length to 100 in .formatter.exs

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -96,7 +96,7 @@
         {Credo.Check.Readability.AliasOrder, []},
         {Credo.Check.Readability.FunctionNames, []},
         {Credo.Check.Readability.LargeNumbers, []},
-        {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
+        {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 100]},
         {Credo.Check.Readability.ModuleAttributeNames, []},
         {Credo.Check.Readability.ModuleDoc, false},
         {Credo.Check.Readability.ModuleNames, []},

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
+  line_length: 100,
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,5 @@
-# Used by "mix format"
 [
   line_length: 100,
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["*.{ex,exs}", "priv/*/seeds.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  subdirectories: ["priv/*/migrations"]
 ]

--- a/lib/nimble.phx.gen.template/addons/ex_machina.ex
+++ b/lib/nimble.phx.gen.template/addons/ex_machina.ex
@@ -26,9 +26,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.ExMachina do
   end
 
   defp inject_mix_dependency(%Project{} = project) do
-    Generator.inject_mix_dependency(
-      {:ex_machina, latest_package_version(:ex_machina), only: :test}
-    )
+    Generator.inject_mix_dependency({:ex_machina, latest_package_version(:ex_machina), only: :test})
 
     project
   end

--- a/lib/nimble.phx.gen.template/addons/test_env.ex
+++ b/lib/nimble.phx.gen.template/addons/test_env.ex
@@ -43,7 +43,13 @@ defmodule Nimble.Phx.Gen.Template.Addons.TestEnv do
     Generator.inject_content(
       ".formatter.exs",
       "[",
-      "\n\tline_length: 100,"
+      String.slice(
+        """
+
+          line_length: 100,
+        """,
+        0..-2
+      )
     )
 
     project

--- a/lib/nimble.phx.gen.template/addons/test_env.ex
+++ b/lib/nimble.phx.gen.template/addons/test_env.ex
@@ -5,6 +5,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.TestEnv do
   def do_apply(%Project{} = project, _opts) do
     project
     |> edit_mix()
+    |> edit_formatter_exs()
     |> edit_test_config()
     |> edit_test_support_cases()
   end
@@ -33,6 +34,16 @@ defmodule Nimble.Phx.Gen.Template.Addons.TestEnv do
       """
         hostname: System.get_env("DB_HOST") || "localhost",
       """
+    )
+
+    project
+  end
+
+  defp edit_formatter_exs(project) do
+    Generator.inject_content(
+      ".formatter.exs",
+      "[",
+      "\n\tline_length: 100,"
     )
 
     project

--- a/priv/templates/nimble.phx.gen.template/.credo.exs
+++ b/priv/templates/nimble.phx.gen.template/.credo.exs
@@ -96,7 +96,7 @@
         {Credo.Check.Readability.AliasOrder, []},
         {Credo.Check.Readability.FunctionNames, []},
         {Credo.Check.Readability.LargeNumbers, []},
-        {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
+        {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 100]},
         {Credo.Check.Readability.ModuleAttributeNames, []},
         {Credo.Check.Readability.ModuleDoc, false},
         {Credo.Check.Readability.ModuleNames, []},

--- a/test/nimble.phx.gen.template/addons/test_env_test.exs
+++ b/test/nimble.phx.gen.template/addons/test_env_test.exs
@@ -34,7 +34,10 @@ defmodule Nimble.Phx.Gen.Template.Addons.TestEnvTest do
         Addons.TestEnv.apply(project)
 
         assert_file(".formatter.exs", fn file ->
-          assert file =~ "\n\tline_length: 100,"
+          assert file =~ """
+                 [
+                   line_length: 100,
+                 """
         end)
       end)
     end

--- a/test/nimble.phx.gen.template/addons/test_env_test.exs
+++ b/test/nimble.phx.gen.template/addons/test_env_test.exs
@@ -26,6 +26,19 @@ defmodule Nimble.Phx.Gen.Template.Addons.TestEnvTest do
       end)
     end
 
+    test "sets line_length: 100 to .formatter.exs", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        Addons.TestEnv.apply(project)
+
+        assert_file(".formatter.exs", fn file ->
+          assert file =~ "\n\tline_length: 100,"
+        end)
+      end)
+    end
+
     test "creates alias Ecto.Adapters.SQL.Sandbox in test support case", %{
       project: project,
       test_project_path: test_project_path

--- a/test/nimble.phx.gen.template/addons/test_env_test.exs
+++ b/test/nimble.phx.gen.template/addons/test_env_test.exs
@@ -26,7 +26,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.TestEnvTest do
       end)
     end
 
-    test "sets line_length: 100 to .formatter.exs", %{
+    test "sets line_length to 100 in .formatter.exs", %{
       project: project,
       test_project_path: test_project_path
     } do


### PR DESCRIPTION
## What happened

Solved https://github.com/nimblehq/elixir-templates/issues/48
 
## Insight

Just add the `line_length: 100,` into the .formatter.exs for the template and the new project
 
## Proof Of Work

1/ The test is passed

2/ New project's .formatter.exs
![image](https://user-images.githubusercontent.com/11751745/99503928-637cb700-29b1-11eb-9077-585412921473.png)

