### PR TITLE
Adding LiveView variant

### DIFF
--- a/.github/workflows/test_live_variant_on_custom_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_custom_liveview_project.yml
@@ -3,10 +3,10 @@ name: "Test Live variant on custom LiveView project"
 on: push
 
 env:
-  OTP_VERSION: 23.1.1
-  ELIXIR_VERSION: 1.11.1
-  PHOENIX_VERSION: 1.5.5
-  NODE_VERSION: 12
+  OTP_VERSION: 23.1.4
+  ELIXIR_VERSION: 1.11.2
+  PHOENIX_VERSION: 1.5.7
+  NODE_VERSION: 14
 
 jobs:   
   unit_test:

--- a/.github/workflows/test_live_variant_on_custom_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_custom_liveview_project.yml
@@ -6,6 +6,7 @@ env:
   OTP_VERSION: 23.1.1
   ELIXIR_VERSION: 1.11.1
   PHOENIX_VERSION: 1.5.5
+  NODE_VERSION: 12
 
 jobs:   
   unit_test:
@@ -32,6 +33,10 @@ jobs:
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
+        
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ env.NODE_VERSION }}
           
       - name: Cache Elixir build
         uses: actions/cache@v2
@@ -42,6 +47,21 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
+             
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=yarn_cache_dir::$(yarn cache dir)"
+      
+      - name: npm packages cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.yarn-cache-dir-path.outputs.yarn_cache_dir }}
+            **/yarn.lock
+            **/node_modules
+          key: ${{ runner.os }}-npm-packages-${{ hashFiles('**/package.json*') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-packages-
               
       - uses: nimblehq/elixir-templates@composite_1.1
         with:

--- a/.github/workflows/test_live_variant_on_custom_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_custom_liveview_project.yml
@@ -1,4 +1,4 @@
-name: "Test Web variant on standard LiveView project"
+name: "Test Live variant on custom LiveView project"
 
 on: push
 
@@ -45,5 +45,5 @@ jobs:
               
       - uses: nimblehq/elixir-templates@composite_1.1
         with:
-          new_project_options: '--live'
+          new_project_options: '--live --module=CustomModule --app=custom_app'
           variant: 'live'

--- a/.github/workflows/test_live_variant_on_standard_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_standard_liveview_project.yml
@@ -1,4 +1,4 @@
-name: "Test Web variant on custom LiveView project"
+name: "Test Live variant on standard LiveView project"
 
 on: push
 
@@ -45,5 +45,5 @@ jobs:
               
       - uses: nimblehq/elixir-templates@composite_1.1
         with:
-          new_project_options: '--live --module=CustomModule --app=custom_app'
+          new_project_options: '--live'
           variant: 'live'

--- a/.github/workflows/test_live_variant_on_standard_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_standard_liveview_project.yml
@@ -6,6 +6,7 @@ env:
   OTP_VERSION: 23.1.1
   ELIXIR_VERSION: 1.11.1
   PHOENIX_VERSION: 1.5.5
+  NODE_VERSION: 12
 
 jobs:   
   unit_test:
@@ -33,6 +34,10 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
           
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          
       - name: Cache Elixir build
         uses: actions/cache@v2
         with:
@@ -42,6 +47,21 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
+           
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=yarn_cache_dir::$(yarn cache dir)"
+      
+      - name: npm packages cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.yarn-cache-dir-path.outputs.yarn_cache_dir }}
+            **/yarn.lock
+            **/node_modules
+          key: ${{ runner.os }}-npm-packages-${{ hashFiles('**/package.json*') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-packages-
               
       - uses: nimblehq/elixir-templates@composite_1.1
         with:

--- a/.github/workflows/test_live_variant_on_standard_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_standard_liveview_project.yml
@@ -3,10 +3,10 @@ name: "Test Live variant on standard LiveView project"
 on: push
 
 env:
-  OTP_VERSION: 23.1.1
-  ELIXIR_VERSION: 1.11.1
-  PHOENIX_VERSION: 1.5.5
-  NODE_VERSION: 12
+  OTP_VERSION: 23.1.4
+  ELIXIR_VERSION: 1.11.2
+  PHOENIX_VERSION: 1.5.7
+  NODE_VERSION: 14
 
 jobs:   
   unit_test:

--- a/.github/workflows/test_variant_on_custom_project.yml
+++ b/.github/workflows/test_variant_on_custom_project.yml
@@ -6,7 +6,7 @@ env:
   OTP_VERSION: 23.1.4
   ELIXIR_VERSION: 1.11.2
   PHOENIX_VERSION: 1.5.7
-  NODE_VERSION: 12
+  NODE_VERSION: 14
 
 jobs:   
   unit_test:

--- a/.github/workflows/test_variant_on_standard_project.yml
+++ b/.github/workflows/test_variant_on_standard_project.yml
@@ -6,7 +6,7 @@ env:
   OTP_VERSION: 23.1.4
   ELIXIR_VERSION: 1.11.2
   PHOENIX_VERSION: 1.5.7
-  NODE_VERSION: 12
+  NODE_VERSION: 14
 
 jobs:   
   unit_test:

--- a/.github/workflows/test_web_variant_on_custom_liveview_project.yml
+++ b/.github/workflows/test_web_variant_on_custom_liveview_project.yml
@@ -1,0 +1,49 @@
+name: "Test Web variant on custom LiveView project"
+
+on: push
+
+env:
+  OTP_VERSION: 23.1.1
+  ELIXIR_VERSION: 1.11.1
+  PHOENIX_VERSION: 1.5.5
+
+jobs:   
+  unit_test:
+    runs-on: ubuntu-latest
+    
+    services:
+      db:
+        image: postgres:12.3
+        ports: ['5432:5432']
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: actions/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+              
+      - uses: nimblehq/elixir-templates@composite_1.1
+        with:
+          new_project_options: '--live --module=CustomModule --app=custom_app'
+          variant: 'live'

--- a/.github/workflows/test_web_variant_on_standard_liveview_project.yml
+++ b/.github/workflows/test_web_variant_on_standard_liveview_project.yml
@@ -1,0 +1,49 @@
+name: "Test Web variant on standard LiveView project"
+
+on: push
+
+env:
+  OTP_VERSION: 23.1.1
+  ELIXIR_VERSION: 1.11.1
+  PHOENIX_VERSION: 1.5.5
+
+jobs:   
+  unit_test:
+    runs-on: ubuntu-latest
+    
+    services:
+      db:
+        image: postgres:12.3
+        ports: ['5432:5432']
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: actions/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+              
+      - uses: nimblehq/elixir-templates@composite_1.1
+        with:
+          new_project_options: '--live'
+          variant: 'live'

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ web_addon_prompts =
 
 api_addon_prompts = 
 
+live_addon_prompts = 
+
 # Y - in response to Fetch and install dependencies?
 post_setup_addon_prompts = Y\n
 
@@ -31,6 +33,8 @@ apply_template:
 		printf "${common_addon_prompts}${web_addon_prompts}${post_setup_addon_prompts}" | mix nimble.phx.gen.template --web; \
 	elif [ $(VARIANT) = api ]; then \
 		printf "${common_addon_prompts}${api_addon_prompts}${post_setup_addon_prompts}" | mix nimble.phx.gen.template --api; \
+	elif [ $(VARIANT) = live ]; then \
+		printf "${common_addon_prompts}${web_addon_prompts}${live_addon_prompts}${post_setup_addon_prompts}" | mix nimble.phx.gen.template --live; \
 	fi;
 
 remove_nimble_phx_gen_template:

--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ All files are located under `test/` folder.
 
 ##### 2.1/ Variant
 
-NimblePhxGenTemplate is supporting 2 variants:  
+NimblePhxGenTemplate is supporting 3 variants:  
 
 - API
 - Web
+- Live
 
 ##### 2.2/ Phoenix project
 
@@ -96,8 +97,8 @@ Putting it all together, it is 8 variant test cases.
 - Applying the `API variant` to a `Custom API project`
 - Applying the `Web variant` to a `Standard Web project`
 - Applying the `Web variant` to a `Custom Web project`
-- Applying the `Web variant` to a `Standard LiveView project`
-- Applying the `Web variant` to a `Custom LiveView project`
+- Applying the `Live variant` to a `Standard LiveView project`
+- Applying the `Live variant` to a `Custom LiveView project`
 
 ### Release
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Then run `mix do deps.get, deps.compile` to install NimblePhxGenTemplate
 mix nimble.phx.gen.template -v # Print the version
 mix nimble.phx.gen.template --web # Apply the Web template
 mix nimble.phx.gen.template --api # Apply the API template
+mix nimble.phx.gen.template --live # Apply the LiveView template
 ```
 ## Requirements
 
@@ -78,14 +79,16 @@ Aside from that, it could also be a Custom project, which contains the custom OT
 - `mix phx.new AppName --app=custom_otp_app_name`
 - `mix phx.new AppName --module=CustomModuleName --app=custom_otp_app_name`
 
-So it ends up with 4 project types:
+So it ends up with 6 project types:
 
 - Standard Web project (`mix phx.new AppName`)
 - Custom Web project (`mix phx.new AppName --module=CustomModuleName --app=custom_otp_app_name`)
 - Standard API project (`mix phx.new AppName --no-html --no-webpack`)
 - Custom API project (`mix phx.new AppName --no-html --no-webpack --module=CustomModuleName --app=custom_otp_app_name`)
+- Standard LiveView project (`mix phx.new AppName --live`)
+- Custom LiveView project (`mix phx.new AppName --live --module=CustomModuleName --app=custom_otp_app_name`)
 
-Putting it all together, it is 6 variant test cases.
+Putting it all together, it is 8 variant test cases.
 
 - Applying the `API variant` to a `Standard Web project`
 - Applying the `API variant` to a `Custom Web project`
@@ -93,6 +96,8 @@ Putting it all together, it is 6 variant test cases.
 - Applying the `API variant` to a `Custom API project`
 - Applying the `Web variant` to a `Standard Web project`
 - Applying the `Web variant` to a `Custom Web project`
+- Applying the `Web variant` to a `Standard LiveView project`
+- Applying the `Web variant` to a `Custom LiveView project`
 
 ### Release
 

--- a/lib/mix/tasks/nimble.phx.gen.template.ex
+++ b/lib/mix/tasks/nimble.phx.gen.template.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Nimble.Phx.Gen.Template do
   alias Nimble.Phx.Gen.Template.{Project, Template}
 
   @version Mix.Project.config()[:version]
-  @variants [api: :boolean, web: :boolean]
+  @variants [api: :boolean, web: :boolean, live: :boolean]
 
   def run([args]) when args in ~w(-v --version) do
     Mix.shell().info("Nimble.Phx.Gen.Template v#{@version}")

--- a/lib/nimble.phx.gen.template/addons/docker.ex
+++ b/lib/nimble.phx.gen.template/addons/docker.ex
@@ -4,7 +4,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.Docker do
   @impl true
   def do_apply(
         %Project{
-          api_project?: api_project?,
+          web_project?: web_project?,
           otp_app: otp_app,
           base_module: base_module,
           docker_build_base_image: docker_build_base_image,
@@ -24,7 +24,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.Docker do
       base_module: base_module,
       docker_build_base_image: docker_build_base_image,
       docker_app_base_image: docker_app_base_image,
-      web_project?: !api_project?
+      web_project?: web_project?
     )
 
     Mix.shell().cmd("chmod +x bin/start.sh")

--- a/lib/nimble.phx.gen.template/addons/ex_coveralls.ex
+++ b/lib/nimble.phx.gen.template/addons/ex_coveralls.ex
@@ -19,11 +19,15 @@ defmodule Nimble.Phx.Gen.Template.Addons.ExCoveralls do
     project
   end
 
-  defp edit_files(%Project{} = project) do
+  defp edit_files(%Project{live_project?: live_project?} = project) do
     project
     |> inject_mix_dependency()
     |> edit_mix()
     |> edit_web_router()
+
+    if live_project?, do: edit_page_live(project)
+
+    project
   end
 
   defp inject_mix_dependency(project) do
@@ -60,6 +64,21 @@ defmodule Nimble.Phx.Gen.Template.Addons.ExCoveralls do
       """,
       """
             coverage: ["coveralls.html --raise"],
+      """
+    )
+
+    project
+  end
+
+  defp edit_page_live(%Project{web_path: web_path, web_module: web_module} = project) do
+    Generator.replace_content(
+      "#{web_path}/live/page_live.ex",
+      """
+      defmodule #{web_module}.PageLive do
+      """,
+      """
+      # coveralls-ignore-start
+      defmodule #{web_module}.PageLive do
       """
     )
 

--- a/lib/nimble.phx.gen.template/addons/github.ex
+++ b/lib/nimble.phx.gen.template/addons/github.ex
@@ -21,12 +21,12 @@ defmodule Nimble.Phx.Gen.Template.Addons.Github do
   end
 
   @impl true
-  def do_apply(%Project{api_project?: api_project?} = project, opts)
+  def do_apply(%Project{web_project?: web_project?} = project, opts)
       when is_map_key(opts, :github_action) do
     binding = [
       otp_version: @versions.otp_version,
       elixir_version: @versions.elixir_version,
-      web_project?: !api_project?
+      web_project?: web_project?
     ]
 
     files = [

--- a/lib/nimble.phx.gen.template/addons/variants/web/core_js.ex
+++ b/lib/nimble.phx.gen.template/addons/variants/web/core_js.ex
@@ -14,17 +14,30 @@ defmodule Nimble.Phx.Gen.Template.Addons.Web.CoreJS do
     project
   end
 
-  def edit_package_json(project) do
-    Generator.replace_content(
-      "assets/package.json",
-      """
-          "phoenix_html": "file:../deps/phoenix_html"
-      """,
-      """
-          "phoenix_html": "file:../deps/phoenix_html",
-          "core-js": "^3.7.0"
-      """
-    )
+  def edit_package_json(%Project{live_project?: live_project?} = project) do
+    if live_project? do
+      Generator.replace_content(
+        "assets/package.json",
+        """
+            "phoenix_html": "file:../deps/phoenix_html",
+        """,
+        """
+            "phoenix_html": "file:../deps/phoenix_html",
+            "core-js": "^3.7.0",
+        """
+      )
+    else
+      Generator.replace_content(
+        "assets/package.json",
+        """
+            "phoenix_html": "file:../deps/phoenix_html"
+        """,
+        """
+            "phoenix_html": "file:../deps/phoenix_html",
+            "core-js": "^3.7.0"
+        """
+      )
+    end
 
     project
   end

--- a/lib/nimble.phx.gen.template/project.ex
+++ b/lib/nimble.phx.gen.template/project.ex
@@ -20,7 +20,9 @@ defmodule Nimble.Phx.Gen.Template.Project do
             web_module: nil,
             web_path: nil,
             web_test_path: nil,
-            api_project?: nil,
+            api_project?: false,
+            web_project?: false,
+            live_project?: false,
             erlang_asdf_version: @default_versions[:erlang_asdf_version],
             elixir_asdf_version: @default_versions[:elixir_asdf_version],
             elixir_mix_version: @default_versions[:elixir_mix_version],
@@ -29,14 +31,26 @@ defmodule Nimble.Phx.Gen.Template.Project do
 
   def new(opts \\ %{}) do
     %__MODULE__{
-      api_project?: opts[:api] === true,
-      otp_app: Mix.Phoenix.otp_app(),
-      base_module: Mix.Phoenix.base(),
-      base_path: "lib/" <> Atom.to_string(Mix.Phoenix.otp_app()),
-      base_test_path: "test/" <> Atom.to_string(Mix.Phoenix.otp_app()),
-      web_module: Mix.Phoenix.base() <> "Web",
-      web_path: "lib/" <> Atom.to_string(Mix.Phoenix.otp_app()) <> "_web",
-      web_test_path: "test/" <> Atom.to_string(Mix.Phoenix.otp_app()) <> "_web"
+      api_project?: api_project?(opts),
+      web_project?: web_project?(opts),
+      live_project?: live_project?(opts),
+      otp_app: otp_app(),
+      base_module: base_module(),
+      base_path: "lib/" <> Atom.to_string(otp_app()),
+      base_test_path: "test/" <> Atom.to_string(otp_app()),
+      web_module: base_module() <> "Web",
+      web_path: "lib/" <> Atom.to_string(otp_app()) <> "_web",
+      web_test_path: "test/" <> Atom.to_string(otp_app()) <> "_web"
     }
   end
+
+  defp api_project?(opts), do: opts[:api] === true
+
+  defp web_project?(opts), do: opts[:web] === true || opts[:live] === true
+
+  defp live_project?(opts), do: opts[:live] === true
+
+  defp otp_app(), do: Mix.Phoenix.otp_app()
+
+  defp base_module(), do: Mix.Phoenix.base()
 end

--- a/lib/nimble.phx.gen.template/template.ex
+++ b/lib/nimble.phx.gen.template/template.ex
@@ -41,8 +41,12 @@ defmodule Nimble.Phx.Gen.Template.Template do
   end
 
   defp variant_setup(%Project{api_project?: true} = project), do: ApiTemplate.apply(project)
-  defp variant_setup(%Project{live_project?: true} = project), do: LiveTemplate.apply(project)
-  defp variant_setup(%Project{web_project?: true} = project), do: WebTemplate.apply(project)
+
+  defp variant_setup(%Project{web_project?: true, live_project?: false} = project),
+    do: WebTemplate.apply(project)
+
+  defp variant_setup(%Project{web_project?: true, live_project?: true} = project),
+    do: LiveTemplate.apply(project)
 
   defp host_on_github?(), do: Mix.shell().yes?("\nWill you host this project on Github?")
 

--- a/lib/nimble.phx.gen.template/template.ex
+++ b/lib/nimble.phx.gen.template/template.ex
@@ -1,5 +1,6 @@
 defmodule Nimble.Phx.Gen.Template.Template do
   alias Nimble.Phx.Gen.Template.Api.Template, as: ApiTemplate
+  alias Nimble.Phx.Gen.Template.Live.Template, as: LiveTemplate
   alias Nimble.Phx.Gen.Template.Web.Template, as: WebTemplate
   alias Nimble.Phx.Gen.Template.{Addons, Project}
 
@@ -40,7 +41,8 @@ defmodule Nimble.Phx.Gen.Template.Template do
   end
 
   defp variant_setup(%Project{api_project?: true} = project), do: ApiTemplate.apply(project)
-  defp variant_setup(%Project{api_project?: false} = project), do: WebTemplate.apply(project)
+  defp variant_setup(%Project{live_project?: true} = project), do: LiveTemplate.apply(project)
+  defp variant_setup(%Project{web_project?: true} = project), do: WebTemplate.apply(project)
 
   defp host_on_github?(), do: Mix.shell().yes?("\nWill you host this project on Github?")
 

--- a/lib/nimble.phx.gen.template/variants/live/template.ex
+++ b/lib/nimble.phx.gen.template/variants/live/template.ex
@@ -1,0 +1,10 @@
+defmodule Nimble.Phx.Gen.Template.Live.Template do
+  alias Nimble.Phx.Gen.Template.Project
+  alias Nimble.Phx.Gen.Template.Web.Template, as: WebTemplate
+
+  def apply(%Project{} = project) do
+    WebTemplate.apply(project)
+
+    project
+  end
+end

--- a/test/nimble.phx.gen.template/addons/docker_test.exs
+++ b/test/nimble.phx.gen.template/addons/docker_test.exs
@@ -95,7 +95,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.DockerTest do
       project: project,
       test_project_path: test_project_path
     } do
-      project = %{project | api_project?: true}
+      project = %{project | api_project?: true, web_project?: false}
 
       in_test_project(test_project_path, fn ->
         Addons.Docker.apply(project)

--- a/test/nimble.phx.gen.template/addons/github_test.exs
+++ b/test/nimble.phx.gen.template/addons/github_test.exs
@@ -30,7 +30,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.GithubTest do
       project: project,
       test_project_path: test_project_path
     } do
-      project = %{project | api_project?: true}
+      project = %{project | api_project?: true, web_project?: false}
 
       in_test_project(test_project_path, fn ->
         Addons.Github.apply(project, %{github_action: true})

--- a/test/support/addon_case.ex
+++ b/test/support/addon_case.ex
@@ -30,8 +30,8 @@ defmodule Nimble.Phx.Gen.Template.AddonCase do
   end
 
   setup context do
-    # Set Web Project as default, switch to either API or Live Project in each test case, for example.
-    # project = %{project | api_project?: true, web_project?: false}
+    # Set Web Project as default, switch to either API or Live Project in each test case
+    # eg: project = %{project | api_project?: true, web_project?: false}
     project = Project.new(web: true)
 
     parent_test_project_path = Path.join(tmp_path(), parent_test_project_path())

--- a/test/support/addon_case.ex
+++ b/test/support/addon_case.ex
@@ -30,7 +30,9 @@ defmodule Nimble.Phx.Gen.Template.AddonCase do
   end
 
   setup context do
-    project = Project.new()
+    # Set Web Project as default, switch to either API or Live Project in each test case, for example.
+    # project = %{project | api_project?: true, web_project?: false}
+    project = Project.new(web: true)
 
     parent_test_project_path = Path.join(tmp_path(), parent_test_project_path())
     test_project_path = Path.join(parent_test_project_path, "/nimble_phx_gen_template")


### PR DESCRIPTION
## What happened

Solved https://github.com/nimblehq/elixir-templates/issues/59

The template could support the Phoenix LiveView project.
 
## Insight

1/ Adding the `--live` option
2/ Refactor the variant a bit, to make it clear between `web/api/live` project
3/ Skip the Code Cover All on the `page_live.ex` as that is the default screen from Phoenix and their don't add a full test for that module.
4/ Test for LiveView Project on Github Action

## Proof Of Work

1/ Tested on my local
2/ Test is passed on Github Action
