### PR TITLE
Adding Mix variant

### DIFF
--- a/.github/workflows/test_api_variant_on_custom_api_project.yml
+++ b/.github/workflows/test_api_variant_on_custom_api_project.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-
               
-      - uses: nimblehq/elixir-templates@composite_1.1
+      - uses: nimblehq/elixir-templates@composite_1.2
         with:
           new_project_options: '--no-html --no-webpack --module=CustomModule --app=custom_app'
           variant: 'api'

--- a/.github/workflows/test_api_variant_on_standard_api_project.yml
+++ b/.github/workflows/test_api_variant_on_standard_api_project.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-
               
-      - uses: nimblehq/elixir-templates@composite_1.1
+      - uses: nimblehq/elixir-templates@composite_1.2
         with:
           new_project_options: '--no-html --no-webpack'
           variant: 'api'

--- a/.github/workflows/test_live_variant_on_custom_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_custom_liveview_project.yml
@@ -63,7 +63,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-packages-
               
-      - uses: nimblehq/elixir-templates@composite_1.1
+      - uses: nimblehq/elixir-templates@composite_1.2
         with:
           new_project_options: '--live --module=CustomModule --app=custom_app'
           variant: 'live'

--- a/.github/workflows/test_live_variant_on_standard_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_standard_liveview_project.yml
@@ -63,7 +63,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-packages-
               
-      - uses: nimblehq/elixir-templates@composite_1.1
+      - uses: nimblehq/elixir-templates@composite_1.2
         with:
           new_project_options: '--live'
           variant: 'live'

--- a/.github/workflows/test_mix_variant_on_custom_mix_project.yml
+++ b/.github/workflows/test_mix_variant_on_custom_mix_project.yml
@@ -1,0 +1,53 @@
+name: "Test Mix variant on custom Mix project"
+
+on: push
+
+env:
+  OTP_VERSION: 23.2.1
+  ELIXIR_VERSION: 1.11.3
+
+jobs:   
+  unit_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: actions/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+              
+      - name: Install Elixir Dependencies 
+        run: mix deps.get
+      
+      - name: Create Mix project
+        run: make create_mix_project PROJECT_DIRECTORY=sample_project OPTIONS="--module=CustomModule --app=custom_app"
+
+      - name: Apply Mix template
+        run: make apply_mix_template PROJECT_DIRECTORY=sample_project
+
+      - name: Install Elixir Dependencies
+        run: cd sample_project && mix deps.get
+      
+      - name: Run mix codebase
+        run: cd sample_project && mix codebase
+        env:
+          MIX_ENV: test
+        
+      - name: Run mix test
+        run: cd sample_project && mix do compile --warnings-as-errors, test
+        env:
+          MIX_ENV: test

--- a/.github/workflows/test_mix_variant_on_custom_mix_project.yml
+++ b/.github/workflows/test_mix_variant_on_custom_mix_project.yml
@@ -3,8 +3,8 @@ name: "Test Mix variant on custom Mix project"
 on: push
 
 env:
-  OTP_VERSION: 23.2.1
-  ELIXIR_VERSION: 1.11.3
+  OTP_VERSION: 23.3
+  ELIXIR_VERSION: 1.11.4
 
 jobs:   
   unit_test:
@@ -15,7 +15,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}

--- a/.github/workflows/test_mix_variant_on_custom_mix_project_with_supervision.yml
+++ b/.github/workflows/test_mix_variant_on_custom_mix_project_with_supervision.yml
@@ -1,0 +1,53 @@
+name: "Test Mix variant on custom Mix project with --sup option"
+
+on: push
+
+env:
+  OTP_VERSION: 23.2.1
+  ELIXIR_VERSION: 1.11.3
+
+jobs:   
+  unit_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: actions/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+              
+      - name: Install Elixir Dependencies 
+        run: mix deps.get
+      
+      - name: Create Mix project
+        run: make create_mix_project PROJECT_DIRECTORY=sample_project OPTIONS="--module=CustomModule --app=custom_app --sup"
+
+      - name: Apply Mix template
+        run: make apply_mix_template PROJECT_DIRECTORY=sample_project
+
+      - name: Install Elixir Dependencies
+        run: cd sample_project && mix deps.get
+      
+      - name: Run mix codebase
+        run: cd sample_project && mix codebase
+        env:
+          MIX_ENV: test
+        
+      - name: Run mix test
+        run: cd sample_project && mix do compile --warnings-as-errors, test
+        env:
+          MIX_ENV: test

--- a/.github/workflows/test_mix_variant_on_custom_mix_project_with_supervision.yml
+++ b/.github/workflows/test_mix_variant_on_custom_mix_project_with_supervision.yml
@@ -3,8 +3,8 @@ name: "Test Mix variant on custom Mix project with --sup option"
 on: push
 
 env:
-  OTP_VERSION: 23.2.1
-  ELIXIR_VERSION: 1.11.3
+  OTP_VERSION: 23.3
+  ELIXIR_VERSION: 1.11.4
 
 jobs:   
   unit_test:
@@ -15,7 +15,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}

--- a/.github/workflows/test_mix_variant_on_standard_mix_project.yml
+++ b/.github/workflows/test_mix_variant_on_standard_mix_project.yml
@@ -1,0 +1,53 @@
+name: "Test Mix variant on standard Mix project"
+
+on: push
+
+env:
+  OTP_VERSION: 23.2.1
+  ELIXIR_VERSION: 1.11.3
+
+jobs:   
+  unit_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: actions/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+              
+      - name: Install Elixir Dependencies 
+        run: mix deps.get
+      
+      - name: Create Mix project
+        run: make create_mix_project PROJECT_DIRECTORY=sample_project OPTIONS=""
+
+      - name: Apply Mix template
+        run: make apply_mix_template PROJECT_DIRECTORY=sample_project
+
+      - name: Install Elixir Dependencies
+        run: cd sample_project && mix deps.get
+      
+      - name: Run mix codebase
+        run: cd sample_project && mix codebase
+        env:
+          MIX_ENV: test
+        
+      - name: Run mix test
+        run: cd sample_project && mix do compile --warnings-as-errors, test
+        env:
+          MIX_ENV: test

--- a/.github/workflows/test_mix_variant_on_standard_mix_project.yml
+++ b/.github/workflows/test_mix_variant_on_standard_mix_project.yml
@@ -3,8 +3,8 @@ name: "Test Mix variant on standard Mix project"
 on: push
 
 env:
-  OTP_VERSION: 23.2.1
-  ELIXIR_VERSION: 1.11.3
+  OTP_VERSION: 23.3
+  ELIXIR_VERSION: 1.11.4
 
 jobs:   
   unit_test:
@@ -15,7 +15,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}

--- a/.github/workflows/test_mix_variant_on_standard_mix_project_with_supervision.yml
+++ b/.github/workflows/test_mix_variant_on_standard_mix_project_with_supervision.yml
@@ -1,0 +1,53 @@
+name: "Test Mix variant on standard Mix project with --sup option"
+
+on: push
+
+env:
+  OTP_VERSION: 23.2.1
+  ELIXIR_VERSION: 1.11.3
+
+jobs:   
+  unit_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: actions/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+              
+      - name: Install Elixir Dependencies 
+        run: mix deps.get
+      
+      - name: Create Mix project
+        run: make create_mix_project PROJECT_DIRECTORY=sample_project OPTIONS="--sup"
+
+      - name: Apply Mix template
+        run: make apply_mix_template PROJECT_DIRECTORY=sample_project
+
+      - name: Install Elixir Dependencies
+        run: cd sample_project && mix deps.get
+      
+      - name: Run mix codebase
+        run: cd sample_project && mix codebase
+        env:
+          MIX_ENV: test
+        
+      - name: Run mix test
+        run: cd sample_project && mix do compile --warnings-as-errors, test
+        env:
+          MIX_ENV: test

--- a/.github/workflows/test_mix_variant_on_standard_mix_project_with_supervision.yml
+++ b/.github/workflows/test_mix_variant_on_standard_mix_project_with_supervision.yml
@@ -3,8 +3,8 @@ name: "Test Mix variant on standard Mix project with --sup option"
 on: push
 
 env:
-  OTP_VERSION: 23.2.1
-  ELIXIR_VERSION: 1.11.3
+  OTP_VERSION: 23.3
+  ELIXIR_VERSION: 1.11.4
 
 jobs:   
   unit_test:
@@ -15,7 +15,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}

--- a/.github/workflows/test_variant_on_custom_web_project.yml
+++ b/.github/workflows/test_variant_on_custom_web_project.yml
@@ -67,7 +67,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-packages-
               
-      - uses: nimblehq/elixir-templates@composite_1.1
+      - uses: nimblehq/elixir-templates@composite_1.2
         with:
           new_project_options: '--module=CustomModule --app=custom_app'
           variant: ${{ matrix.variant }}

--- a/.github/workflows/test_variant_on_standard_web_project.yml
+++ b/.github/workflows/test_variant_on_standard_web_project.yml
@@ -67,7 +67,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-packages-
               
-      - uses: nimblehq/elixir-templates@composite_1.1
+      - uses: nimblehq/elixir-templates@composite_1.2
         with:
           new_project_options: ''
           variant: ${{ matrix.variant }}

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
-.PHONY: install_phoenix create_project apply_template remove_nimble_phx_gen_template
+.PHONY: install_phoenix create_phoenix_project apply_phoenix_template create_mix_project apply_mix_template remove_nimble_phx_gen_template
 
 # Y - in response to Are you sure you want to install "phx_new-${PHOENIX_VERSION}.ez"?
 install_phoenix:
 	printf "Y\n" | mix archive.install hex phx_new ${PHOENIX_VERSION}
 
-create_project:
+create_phoenix_project:
 	mix phx.new ${PROJECT_DIRECTORY} ${OPTIONS}
+	
+create_mix_project:
+	mix new ${PROJECT_DIRECTORY} ${OPTIONS}
 
 # Y - in response to Will you host this project on Github?
 # Y - in response to Do you want to generate the .github/ISSUE_TEMPLATE and .github/PULL_REQUEST_TEMPLATE?
@@ -19,10 +22,16 @@ api_addon_prompts =
 
 live_addon_prompts = 
 
+# Y - in response to Will you host this project on Github?
+# Y - in response to Do you want to generate the .github/ISSUE_TEMPLATE and .github/PULL_REQUEST_TEMPLATE?
+# Y - in response to Do you want to generate the Github Action workflow?
+# Y - in response to Would you like to add the Mimic addon?
+mix_addon_prompts = Y\nY\nY\nY\n
+
 # Y - in response to Fetch and install dependencies?
 post_setup_addon_prompts = Y\n
 
-apply_template:
+apply_phoenix_template:
 	cd ${PROJECT_DIRECTORY} && \
 	echo '{:nimble_phx_gen_template, path: "../", only: :dev, runtime: false},' > nimble_phx_gen_template.txt && \
 	sed -i -e '/{:phoenix, "~> /r nimble_phx_gen_template.txt' mix.exs && \
@@ -36,6 +45,15 @@ apply_template:
 	elif [ $(VARIANT) = live ]; then \
 		printf "${common_addon_prompts}${web_addon_prompts}${live_addon_prompts}${post_setup_addon_prompts}" | mix nimble.phx.gen.template --live; \
 	fi;
+	
+apply_mix_template:
+	cd ${PROJECT_DIRECTORY} && \
+	echo '{:nimble_phx_gen_template, path: "../", only: :dev, runtime: false}' > nimble_phx_gen_template.txt && \
+	sed -i -e '/# {:dep_from_git, /r nimble_phx_gen_template.txt' mix.exs && \
+	rm nimble_phx_gen_template.txt && \
+	mix deps.get && \
+	mix format && \
+	printf "${mix_addon_prompts}${post_setup_addon_prompts}" | mix nimble.phx.gen.template --mix; \
 
 remove_nimble_phx_gen_template:
 	cd ${PROJECT_DIRECTORY} && \

--- a/README.md
+++ b/README.md
@@ -12,12 +12,16 @@ NimblePhxGenTemplate has been developed and actively tested with the below envir
 
 ## Installation
 
-*Note:* NimblePhxGenTemplate only works on a _new_ Phoenix project, applying it to an existing Phoenix project might not work as expected.
+*Note:* NimblePhxGenTemplate only works on a _new_ Phoenix/Mix project, applying it to an existing Phoenix/Mix project might not work as expected.
 
-Step 1: Generate a new Phoenix project
+Step 1: Generate a new project
 
 ```bash
+# New Phoenix project
 mix phx.new awesome_project
+
+# New Mix project
+mix new awesome_project
 ```
 
 Step 2: Add `nimble_phx_gen_template` dependency to `mix.exs`:
@@ -41,11 +45,18 @@ mix do deps.get, deps.compile
 
 ## Usage
 
-```
-mix nimble.phx.gen.template -v      # Print the version
+```bash
+mix help nimble.phx.gen.template # Print help
+
+mix nimble.phx.gen.template -v # Print the version
+
+# Phoenix application
 mix nimble.phx.gen.template --web   # Apply the Web template
 mix nimble.phx.gen.template --api   # Apply the API template
 mix nimble.phx.gen.template --live  # Apply the LiveView template
+
+# Non-Phoenix application
+mix nimble.phx.gen.template --mix # Apply the Mix template
 ```
 
 ## Running tests
@@ -72,6 +83,12 @@ All test files are located under `test/` directory.
 │   │   │   │   └── api
 │   │   │   │   │   ├── ...
 │   │   │   │   │   └── api_addon_test.exs
+│   │   │   │   └── live
+│   │   │   │   │   ├── ...
+│   │   │   │   │   └── live_addon_test.exs
+│   │   │   │   └── mix
+│   │   │   │   │   ├── ...
+│   │   │   │   │   └── mix_addon_test.exs
 │   │   │   │   └── web
 │   │   │   │   │   ├── ...
 │   │   │   │   │   └── web_addon_test.exs
@@ -81,11 +98,12 @@ All test files are located under `test/` directory.
 
 #### 2.1/ Variant
 
-NimblePhxGenTemplate supports 3 variants:  
+NimblePhxGenTemplate supports 4 variants:  
 
 - API
-- Web
 - Live
+- Web
+- Mix
 
 #### 2.2/ Phoenix project
 
@@ -95,6 +113,12 @@ The Phoenix project could be either a Web or API project.
 
 ```bash
 mix phx.new awesome_project
+```
+
+- LiveView project is including HTML and Webpack configuration.
+
+```bash
+mix phx.new awesome_project --live
 ```
 
 - API variant does NOT support HTML and Webpack configuration.
@@ -140,6 +164,29 @@ Putting it all together, there are 8 variants of test cases.
 - Applying the `Web variant` to a `Custom Web project`
 - Applying the `Live variant` to a `Standard LiveView project`
 - Applying the `Live variant` to a `Custom LiveView project`
+
+##### 2.2/ Mix project
+
+The Mix project could be either a Standard project or a Custom project.
+
+- `mix new awesome_project`
+- `mix new awesome_project --module=CustomModuleName`
+- `mix new awesome_project --app=custom_otp_app_name`
+- `mix new awesome_project --module=CustomModuleName --app=custom_otp_app_name`
+
+Each project could be include the `supervision tree` or not.
+
+- `mix new awesome_project`
+- `mix new awesome_project --sup`
+- `mix new awesome_project --module=CustomModuleName --app=custom_otp_app_name`
+- `mix new awesome_project --module=CustomModuleName --app=custom_otp_app_name --sup`
+
+Putting it all together, it will has 4 variant test cases.
+
+- Applying the `Mix variant` to a `Standard Mix project`
+- Applying the `Mix variant` to a `Custom Mix project`
+- Applying the `Mix variant` to a `Standard Mix project with the --sup option`
+- Applying the `Mix variant` to a `Custom Mix project with the --sup option`
 
 ### Release
 

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install Dependencies 
+    - name: Install Elixir Dependencies 
       run: mix deps.get
       shell: bash
     
@@ -16,12 +16,12 @@ runs:
       shell: bash
     
       # Y - in response to Fetch and install dependencies?
-    - name: Create project
-      run: printf "Y\n" | make create_project PROJECT_DIRECTORY=sample_project OPTIONS="${{ inputs.new_project_options }}"
+    - name: Create Phoenix project
+      run: printf "Y\n" | make create_phoenix_project PROJECT_DIRECTORY=sample_project OPTIONS="${{ inputs.new_project_options }}"
       shell: bash
     
-    - name: Apply template
-      run: make apply_template PROJECT_DIRECTORY=sample_project VARIANT=${{ inputs.variant }}
+    - name: Apply Phoenix template
+      run: make apply_phoenix_template PROJECT_DIRECTORY=sample_project VARIANT=${{ inputs.variant }}
       shell: bash
 
     - name: Install Elixir Dependencies

--- a/lib/mix/tasks/nimble.phx.gen.template.ex
+++ b/lib/mix/tasks/nimble.phx.gen.template.ex
@@ -1,12 +1,32 @@
 defmodule Mix.Tasks.Nimble.Phx.Gen.Template do
-  @shortdoc "Generates Nimble's Phoenix template"
+  @shortdoc "Apply Nimble's Elixir/Phoenix template"
+  @moduledoc """
+  #{@shortdoc}
+
+  - Hex package: https://hex.pm/packages/nimble_phx_gen_template
+  - Github: https://github.com/nimblehq/elixir-templates
+
+  # Usage
+
+  - mix nimble.phx.gen.template -v # Print the version
+
+  ## Phoenix application
+
+  - mix nimble.phx.gen.template --api # Apply the Phoenix API template
+  - mix nimble.phx.gen.template --live # Apply the Phoenix LiveView template
+  - mix nimble.phx.gen.template --web # Apply the Phoenix Web template
+
+  ## Non-Phoenix application
+
+  - mix nimble.phx.gen.template --mix # Apply the Mix template
+  """
 
   use Mix.Task
 
   alias Nimble.Phx.Gen.Template.{Project, Template}
 
   @version Mix.Project.config()[:version]
-  @variants [api: :boolean, web: :boolean, live: :boolean]
+  @variants [api: :boolean, web: :boolean, live: :boolean, mix: :boolean]
 
   def run([args]) when args in ~w(-v --version) do
     Mix.shell().info("Nimble.Phx.Gen.Template v#{@version}")

--- a/lib/mix/tasks/nimble.phx.gen.template.ex
+++ b/lib/mix/tasks/nimble.phx.gen.template.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Nimble.Phx.Gen.Template do
   @shortdoc "Apply Nimble's Elixir/Phoenix template"
+
   @moduledoc """
   #{@shortdoc}
 

--- a/lib/mix/tasks/nimble.phx.gen.template.ex
+++ b/lib/mix/tasks/nimble.phx.gen.template.ex
@@ -29,7 +29,8 @@ defmodule Mix.Tasks.Nimble.Phx.Gen.Template do
   @version Mix.Project.config()[:version]
   @variants [api: :boolean, web: :boolean, live: :boolean, mix: :boolean]
 
-  def run([args]) when args in ~w(-v --version), do: Mix.shell().info("Nimble.Phx.Gen.Template v#{@version}")
+  def run([args]) when args in ~w(-v --version),
+    do: Mix.shell().info("Nimble.Phx.Gen.Template v#{@version}")
 
   def run(args) do
     if Mix.Project.umbrella?() do

--- a/lib/mix/tasks/nimble.phx.gen.template.ex
+++ b/lib/mix/tasks/nimble.phx.gen.template.ex
@@ -11,13 +11,13 @@ defmodule Mix.Tasks.Nimble.Phx.Gen.Template do
 
   - mix nimble.phx.gen.template -v # Print the version
 
-  ## Phoenix application
+  ### Phoenix application
 
   - mix nimble.phx.gen.template --api # Apply the Phoenix API template
   - mix nimble.phx.gen.template --live # Apply the Phoenix LiveView template
   - mix nimble.phx.gen.template --web # Apply the Phoenix Web template
 
-  ## Non-Phoenix application
+  ### Non-Phoenix application
 
   - mix nimble.phx.gen.template --mix # Apply the Mix template
   """
@@ -29,9 +29,7 @@ defmodule Mix.Tasks.Nimble.Phx.Gen.Template do
   @version Mix.Project.config()[:version]
   @variants [api: :boolean, web: :boolean, live: :boolean, mix: :boolean]
 
-  def run([args]) when args in ~w(-v --version) do
-    Mix.shell().info("Nimble.Phx.Gen.Template v#{@version}")
-  end
+  def run([args]) when args in ~w(-v --version), do: Mix.shell().info("Nimble.Phx.Gen.Template v#{@version}")
 
   def run(args) do
     if Mix.Project.umbrella?() do

--- a/lib/nimble.phx.gen.template/addons/credo.ex
+++ b/lib/nimble.phx.gen.template/addons/credo.ex
@@ -28,6 +28,20 @@ defmodule Nimble.Phx.Gen.Template.Addons.Credo do
     project
   end
 
+  defp edit_mix(%Project{mix_project?: true} = project) do
+    Generator.replace_content(
+      "mix.exs",
+      """
+            codebase: ["deps.unlock --check-unused", "format --check-formatted"]
+      """,
+      """
+            codebase: ["deps.unlock --check-unused", "format --check-formatted", "credo --strict"]
+      """
+    )
+
+    project
+  end
+
   defp edit_mix(project) do
     Generator.replace_content(
       "mix.exs",

--- a/lib/nimble.phx.gen.template/addons/ex_coveralls.ex
+++ b/lib/nimble.phx.gen.template/addons/ex_coveralls.ex
@@ -8,13 +8,28 @@ defmodule Nimble.Phx.Gen.Template.Addons.ExCoveralls do
     |> edit_files()
   end
 
-  defp copy_files(%Project{otp_app: otp_app} = project) do
+  defp copy_files(%Project{otp_app: otp_app, mix_project?: mix_project?} = project) do
     binding = [
       otp_app: otp_app,
       minimum_coverage: 100
     ]
 
-    Generator.copy_file([{:eex, "coveralls.json.eex", "coveralls.json"}], binding)
+    template_file_path =
+      if mix_project? do
+        "coveralls.json.mix.eex"
+      else
+        "coveralls.json.eex"
+      end
+
+    Generator.copy_file([{:eex, template_file_path, "coveralls.json"}], binding)
+
+    project
+  end
+
+  defp edit_files(%Project{mix_project?: true} = project) do
+    project
+    |> inject_mix_dependency()
+    |> edit_mix()
 
     project
   end

--- a/lib/nimble.phx.gen.template/addons/github.ex
+++ b/lib/nimble.phx.gen.template/addons/github.ex
@@ -19,6 +19,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.Github do
   def do_apply(
         %Project{
           web_project?: web_project?,
+          mix_project?: mix_project?,
           erlang_version: erlang_version,
           elixir_version: elixir_version,
           node_version: node_version
@@ -33,8 +34,15 @@ defmodule Nimble.Phx.Gen.Template.Addons.Github do
       web_project?: web_project?
     ]
 
+    template_file_path =
+      if mix_project? do
+        ".github/workflows/test.yml.mix.eex"
+      else
+        ".github/workflows/test.yml.eex"
+      end
+
     files = [
-      {:eex, ".github/workflows/test.yml.eex", ".github/workflows/test.yml"}
+      {:eex, template_file_path, ".github/workflows/test.yml"}
     ]
 
     Generator.copy_file(files, binding)

--- a/lib/nimble.phx.gen.template/addons/readme.ex
+++ b/lib/nimble.phx.gen.template/addons/readme.ex
@@ -16,15 +16,23 @@ defmodule Nimble.Phx.Gen.Template.Addons.Readme do
 
   defp copy_files(
          %Project{
-           api_project?: api_project?,
+           web_project?: web_project?,
+           mix_project?: mix_project?,
            erlang_version: erlang_version,
            elixir_version: elixir_version
          } = project
        ) do
-    Generator.copy_file([{:eex, "README.md.eex", "README.md"}],
+    template_file_path =
+      if mix_project? do
+        "README.md.mix.eex"
+      else
+        "README.md.eex"
+      end
+
+    Generator.copy_file([{:eex, template_file_path, "README.md"}],
       erlang_version: erlang_version,
       elixir_version: elixir_version,
-      web_project?: !api_project?
+      web_project?: web_project?
     )
 
     project

--- a/lib/nimble.phx.gen.template/addons/test_env.ex
+++ b/lib/nimble.phx.gen.template/addons/test_env.ex
@@ -2,6 +2,14 @@ defmodule Nimble.Phx.Gen.Template.Addons.TestEnv do
   use Nimble.Phx.Gen.Template.Addon
 
   @impl true
+  def do_apply(%Project{mix_project?: true} = project, _opts) do
+    project
+    |> edit_mix()
+    |> edit_formatter_exs()
+    |> edit_test_helper()
+  end
+
+  @impl true
   def do_apply(%Project{} = project, _opts) do
     project
     |> edit_mix()
@@ -9,6 +17,42 @@ defmodule Nimble.Phx.Gen.Template.Addons.TestEnv do
     |> edit_test_helper()
     |> edit_test_config()
     |> edit_test_support_cases()
+  end
+
+  defp edit_mix(%Project{mix_project?: true} = project) do
+    Generator.replace_content(
+      "mix.exs",
+      """
+            deps: deps()
+      """,
+      """
+            elixirc_paths: elixirc_paths(Mix.env()),
+            aliases: aliases(),
+            deps: deps()
+      """
+    )
+
+    Generator.replace_content(
+      "mix.exs",
+      """
+        # Run "mix help deps" to learn about dependencies.
+      """,
+      """
+        defp aliases do
+          [
+            codebase: ["deps.unlock --check-unused", "format --check-formatted"]
+          ]
+        end
+
+        # Specifies which paths to compile per environment.
+        defp elixirc_paths(:test), do: ["lib", "test/support"]
+        defp elixirc_paths(_), do: ["lib"]
+
+        # Run "mix help deps" to learn about dependencies.
+      """
+    )
+
+    project
   end
 
   defp edit_mix(project) do

--- a/lib/nimble.phx.gen.template/project.ex
+++ b/lib/nimble.phx.gen.template/project.ex
@@ -24,7 +24,8 @@ defmodule Nimble.Phx.Gen.Template.Project do
             # Variants
             api_project?: false,
             live_project?: false,
-            web_project?: false
+            web_project?: false,
+            mix_project?: false
 
   def new(opts \\ %{}) do
     %__MODULE__{
@@ -37,7 +38,8 @@ defmodule Nimble.Phx.Gen.Template.Project do
       web_test_path: "test/" <> Atom.to_string(otp_app()) <> "_web",
       api_project?: api_project?(opts),
       web_project?: web_project?(opts),
-      live_project?: live_project?(opts)
+      live_project?: live_project?(opts),
+      mix_project?: mix_project?(opts),
     }
   end
 
@@ -46,6 +48,8 @@ defmodule Nimble.Phx.Gen.Template.Project do
   defp web_project?(opts), do: opts[:web] === true || opts[:live] === true
 
   defp live_project?(opts), do: opts[:live] === true
+
+  defp mix_project?(opts), do: opts[:mix] === true
 
   defp otp_app(), do: Mix.Phoenix.otp_app()
 

--- a/lib/nimble.phx.gen.template/project.ex
+++ b/lib/nimble.phx.gen.template/project.ex
@@ -39,7 +39,7 @@ defmodule Nimble.Phx.Gen.Template.Project do
       api_project?: api_project?(opts),
       web_project?: web_project?(opts),
       live_project?: live_project?(opts),
-      mix_project?: mix_project?(opts),
+      mix_project?: mix_project?(opts)
     }
   end
 

--- a/lib/nimble.phx.gen.template/template.ex
+++ b/lib/nimble.phx.gen.template/template.ex
@@ -1,8 +1,15 @@
 defmodule Nimble.Phx.Gen.Template.Template do
   alias Nimble.Phx.Gen.Template.Api.Template, as: ApiTemplate
   alias Nimble.Phx.Gen.Template.Live.Template, as: LiveTemplate
+  alias Nimble.Phx.Gen.Template.Mix.Template, as: MixTemplate
   alias Nimble.Phx.Gen.Template.Web.Template, as: WebTemplate
   alias Nimble.Phx.Gen.Template.{Addons, Project}
+
+  def apply(%Project{mix_project?: true} = project) do
+    MixTemplate.apply(project)
+
+    if Mix.shell().yes?("\nFetch and install dependencies?"), do: Mix.shell().cmd("mix deps.get")
+  end
 
   def apply(%Project{} = project) do
     project
@@ -11,6 +18,20 @@ defmodule Nimble.Phx.Gen.Template.Template do
 
     if Mix.shell().yes?("\nFetch and install dependencies?"), do: Mix.shell().cmd("mix deps.get")
   end
+
+  def host_on_github?(), do: Mix.shell().yes?("\nWill you host this project on Github?")
+
+  def generate_github_template?(),
+    do:
+      Mix.shell().yes?(
+        "\nDo you want to generate the .github/ISSUE_TEMPLATE and .github/PULL_REQUEST_TEMPLATE?"
+      )
+
+  def generate_github_action?(),
+    do: Mix.shell().yes?("\nDo you want to generate the Github Action workflow?")
+
+  def install_addon_prompt?(addon),
+    do: Mix.shell().yes?("\nWould you like to add the #{addon} addon?")
 
   # Common setup for both API and Web projects
   defp common_setup(%Project{} = project) do
@@ -47,18 +68,4 @@ defmodule Nimble.Phx.Gen.Template.Template do
 
   defp variant_setup(%Project{web_project?: true, live_project?: true} = project),
     do: LiveTemplate.apply(project)
-
-  defp host_on_github?(), do: Mix.shell().yes?("\nWill you host this project on Github?")
-
-  defp generate_github_template?(),
-    do:
-      Mix.shell().yes?(
-        "\nDo you want to generate the .github/ISSUE_TEMPLATE and .github/PULL_REQUEST_TEMPLATE?"
-      )
-
-  defp generate_github_action?(),
-    do: Mix.shell().yes?("\nDo you want to generate the Github Action workflow?")
-
-  defp install_addon_prompt?(addon),
-    do: Mix.shell().yes?("\nWould you like to add the #{addon} addon?")
 end

--- a/lib/nimble.phx.gen.template/variants/mix/template.ex
+++ b/lib/nimble.phx.gen.template/variants/mix/template.ex
@@ -1,0 +1,33 @@
+defmodule Nimble.Phx.Gen.Template.Mix.Template do
+  import Nimble.Phx.Gen.Template.Template,
+    only: [
+      host_on_github?: 0,
+      generate_github_template?: 0,
+      generate_github_action?: 0,
+      install_addon_prompt?: 1
+    ]
+
+  alias Nimble.Phx.Gen.Template.{Addons, Project}
+
+  def apply(%Project{} = project) do
+    project
+    |> Addons.ElixirVersion.apply()
+    |> Addons.Readme.apply()
+    |> Addons.TestEnv.apply()
+    |> Addons.Credo.apply()
+    |> Addons.Dialyxir.apply()
+    |> Addons.ExCoveralls.apply()
+
+    if host_on_github?() do
+      if generate_github_template?(),
+        do: Addons.Github.apply(project, %{github_template: true})
+
+      if generate_github_action?(),
+        do: Addons.Github.apply(project, %{github_action: true})
+    end
+
+    if install_addon_prompt?("Mimic"), do: Addons.Mimic.apply(project)
+
+    project
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule NimblePhxGenTemplate.MixProject do
+defmodule Nimble.Phx.Gen.Template.MixProject do
   use Mix.Project
 
   def project do

--- a/priv/templates/nimble.phx.gen.template/.github/workflows/test.yml.mix.eex
+++ b/priv/templates/nimble.phx.gen.template/.github/workflows/test.yml.mix.eex
@@ -1,0 +1,42 @@
+name: "Tests"
+
+on: pull_request
+
+env:
+  OTP_VERSION: <%= inspect erlang_version %>
+  ELIXIR_VERSION: <%= inspect elixir_version %>
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: actions/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - name: Install Dependencies
+        run: mix deps.get
+
+      - name: Run codebase check
+        run: mix codebase
+
+      - name: Run Tests
+        run: mix do compile --warnings-as-errors, coverage
+        env:
+          MIX_ENV: test

--- a/priv/templates/nimble.phx.gen.template/.github/workflows/test.yml.mix.eex
+++ b/priv/templates/nimble.phx.gen.template/.github/workflows/test.yml.mix.eex
@@ -15,7 +15,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}

--- a/priv/templates/nimble.phx.gen.template/README.md.mix.eex
+++ b/priv/templates/nimble.phx.gen.template/README.md.mix.eex
@@ -1,0 +1,45 @@
+[![Build Status](CI_BADGE_URL goes here)](REPO_URL goes here)
+
+## Introduction
+
+> *App introduction goes here ...*
+
+## Project Setup
+
+### Erlang & Elixir
+
+* Erlang <%= erlang_version %>
+
+* Elixir <%= elixir_version %>
+
+* Recommended version manager.
+
+  - [asdf](https://github.com/asdf-vm/asdf)
+  - [asdf-erlang](https://github.com/asdf-vm/asdf-erlang)
+  - [asdf-elixir](https://github.com/asdf-vm/asdf-elixir)
+
+### Development
+
+* Install Elixir dependencies:
+
+  ```sh
+  mix deps.get
+  ```
+
+* Run all tests:
+
+  ```sh
+  mix test 
+  ```
+
+* Run all lint:
+
+  ```sh
+  mix codebase 
+  ```
+
+* Test coverage:
+
+  ```sh
+  mix coverage 
+  ```

--- a/priv/templates/nimble.phx.gen.template/coveralls.json.mix.eex
+++ b/priv/templates/nimble.phx.gen.template/coveralls.json.mix.eex
@@ -1,0 +1,9 @@
+{
+  "skip_files": [
+    "lib/<%= otp_app %>/application.ex",
+    "test/support"
+  ],
+  "coverage_options": {
+    "minimum_coverage": <%= minimum_coverage %>
+  }
+}

--- a/test/nimble.phx.gen.template/addons/credo_test.exs
+++ b/test/nimble.phx.gen.template/addons/credo_test.exs
@@ -47,4 +47,52 @@ defmodule Nimble.Phx.Gen.Template.Addons.CredoTest do
       end)
     end
   end
+
+  describe "#apply/2 with mix_project" do
+    @describetag mix_project?: true
+    @describetag mock_latest_package_versions: [{:credo, "1.4"}]
+    @describetag required_addons: [:TestEnv]
+
+    test "copies the .credo.exs", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        Addons.Credo.apply(project)
+
+        assert_file(".credo.exs")
+      end)
+    end
+
+    test "injects credo to mix dependency", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        Addons.Credo.apply(project)
+
+        assert_file("mix.exs", fn file ->
+          assert file =~ """
+                   defp deps do
+                     [
+                       {:credo, \"~> 1.4\", [only: [:dev, :test], runtime: false]},
+                 """
+        end)
+      end)
+    end
+
+    test "adds credo codebase alias", %{project: project, test_project_path: test_project_path} do
+      in_test_project(test_project_path, fn ->
+        Addons.Credo.apply(project)
+
+        assert_file("mix.exs", fn file ->
+          assert file =~ """
+                   defp aliases do
+                     [
+                       codebase: [\"deps.unlock --check-unused\", \"format --check-formatted\", \"credo --strict\"]
+                 """
+        end)
+      end)
+    end
+  end
 end

--- a/test/nimble.phx.gen.template/addons/ex_coveralls_test.exs
+++ b/test/nimble.phx.gen.template/addons/ex_coveralls_test.exs
@@ -65,4 +65,71 @@ defmodule Nimble.Phx.Gen.Template.Addons.ExCoverallsTest do
       end)
     end
   end
+
+  describe "#apply/2 with mix_project" do
+    @describetag mix_project?: true
+    @describetag required_addons: [:TestEnv]
+    @describetag mock_latest_package_versions: [{:excoveralls, "0.12.2"}]
+
+    test "copies the coveralls.json", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        Addons.ExCoveralls.apply(project)
+
+        assert_file("coveralls.json")
+      end)
+    end
+
+    test "injects excoveralls to mix dependency", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        Addons.ExCoveralls.apply(project)
+
+        assert_file("mix.exs", fn file ->
+          assert file =~ """
+                   defp deps do
+                     [
+                       {:excoveralls, \"~> 0.12.2\", [only: :test]},
+                 """
+        end)
+      end)
+    end
+
+    test "sets ExCoveralls tool", %{project: project, test_project_path: test_project_path} do
+      in_test_project(test_project_path, fn ->
+        Addons.ExCoveralls.apply(project)
+
+        assert_file("mix.exs", fn file ->
+          assert file =~ """
+                     deps: deps(),
+                       test_coverage: [tool: ExCoveralls],
+                       preferred_cli_env: [
+                         lint: :test,
+                         coverage: :test,
+                         coveralls: :test,
+                         "coveralls.html": :test
+                       ]
+                 """
+        end)
+      end)
+    end
+
+    test "adds coverage alias", %{project: project, test_project_path: test_project_path} do
+      in_test_project(test_project_path, fn ->
+        Addons.ExCoveralls.apply(project)
+
+        assert_file("mix.exs", fn file ->
+          assert file =~ """
+                   defp aliases do
+                     [
+                       coverage: [\"coveralls.html --raise\"],
+                 """
+        end)
+      end)
+    end
+  end
 end

--- a/test/nimble.phx.gen.template/addons/github_test.exs
+++ b/test/nimble.phx.gen.template/addons/github_test.exs
@@ -25,8 +25,34 @@ defmodule Nimble.Phx.Gen.Template.Addons.GithubTest do
     end
   end
 
+  describe "#apply/2 with mix_project and github_template option" do
+    @describetag mix_project?: true
+
+    test "copies the .github/ISSUE_TEMPLATE.md", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        Addons.Github.apply(project, %{github_template: true})
+
+        assert_file(".github/ISSUE_TEMPLATE.md")
+      end)
+    end
+
+    test "copies the .github/PULL_REQUEST_TEMPLATE.md", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        Addons.Github.apply(project, %{github_template: true})
+
+        assert_file(".github/PULL_REQUEST_TEMPLATE.md")
+      end)
+    end
+  end
+
   describe "#apply/2 with api_project and github_action option" do
-    test "copies the .credo.exs", %{
+    test "does NOT include the npm setting", %{
       project: project,
       test_project_path: test_project_path
     } do
@@ -46,7 +72,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.GithubTest do
   end
 
   describe "#apply/2 with web_project and github_action option" do
-    test "copies the .credo.exs", %{
+    test "includes the npm setting", %{
       project: project,
       test_project_path: test_project_path
     } do
@@ -58,6 +84,41 @@ defmodule Nimble.Phx.Gen.Template.Addons.GithubTest do
           assert file =~ "npm --prefix assets install"
           assert file =~ "npm run --prefix assets build:dev"
           assert file =~ "wallaby_screenshots"
+        end)
+      end)
+    end
+  end
+
+  describe "#apply/2 with mix_project and github_action option" do
+    @describetag mix_project?: true
+
+    test "does NOT include database setting", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        Addons.Github.apply(project, %{github_action: true})
+
+        assert_file(".github/workflows/test.yml", fn file ->
+          refute file =~ "postgres"
+          refute file =~ "ecto.create"
+          refute file =~ "ecto.migrate"
+        end)
+      end)
+    end
+
+    test "does NOT include the npm setting", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        Addons.Github.apply(project, %{github_action: true})
+
+        assert_file(".github/workflows/test.yml", fn file ->
+          refute file =~ "assets/node_modules"
+          refute file =~ "npm --prefix assets install"
+          refute file =~ "npm run --prefix assets build:dev"
+          refute file =~ "wallaby_screenshots"
         end)
       end)
     end

--- a/test/nimble.phx.gen.template/addons/readme_test.exs
+++ b/test/nimble.phx.gen.template/addons/readme_test.exs
@@ -44,8 +44,8 @@ defmodule Nimble.Phx.Gen.Template.Addons.ReadmeTest do
         Addons.Readme.apply(project)
 
         assert_file("README.md", fn file ->
-          assert file =~ "Erlang 23.2.1"
-          assert file =~ "Elixir 1.11.3"
+          assert file =~ "Erlang 23.3"
+          assert file =~ "Elixir 1.11.4"
 
           refute file =~ """
                  * Install Node dependencies:

--- a/test/nimble.phx.gen.template/addons/readme_test.exs
+++ b/test/nimble.phx.gen.template/addons/readme_test.exs
@@ -20,6 +20,14 @@ defmodule Nimble.Phx.Gen.Template.Addons.ReadmeTest do
                    npm install --prefix assets
                    ```
                  """
+
+          assert file =~ """
+                 * Start the Phoenix app
+
+                   ```sh
+                   iex -S mix phx.server
+                   ```
+                 """
         end)
       end)
     end
@@ -30,8 +38,42 @@ defmodule Nimble.Phx.Gen.Template.Addons.ReadmeTest do
       project: project,
       test_project_path: test_project_path
     } do
-      project = %{project | api_project?: true}
+      project = %{project | api_project?: true, web_project?: false}
 
+      in_test_project(test_project_path, fn ->
+        Addons.Readme.apply(project)
+
+        assert_file("README.md", fn file ->
+          assert file =~ "Erlang 23.2.1"
+          assert file =~ "Elixir 1.11.3"
+
+          refute file =~ """
+                 * Install Node dependencies:
+
+                   ```sh
+                   npm install --prefix assets
+                   ```
+                 """
+
+          assert file =~ """
+                 * Start the Phoenix app
+
+                   ```sh
+                   iex -S mix phx.server
+                   ```
+                 """
+        end)
+      end)
+    end
+  end
+
+  describe "#apply/2 with mix_project" do
+    @describetag mix_project?: true
+
+    test "copies the README.md", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
       in_test_project(test_project_path, fn ->
         Addons.Readme.apply(project)
 
@@ -44,6 +86,14 @@ defmodule Nimble.Phx.Gen.Template.Addons.ReadmeTest do
 
                    ```sh
                    npm install --prefix assets
+                   ```
+                 """
+
+          refute file =~ """
+                 * Start the Phoenix app
+
+                   ```sh
+                   iex -S mix phx.server
                    ```
                  """
         end)

--- a/test/nimble.phx.gen.template/addons/test_env_test.exs
+++ b/test/nimble.phx.gen.template/addons/test_env_test.exs
@@ -74,4 +74,73 @@ defmodule Nimble.Phx.Gen.Template.Addons.TestEnvTest do
       end)
     end
   end
+
+  describe "#apply/2 with mix_project" do
+    @describetag mix_project?: true
+
+    test "adds codebase alias", %{project: project, test_project_path: test_project_path} do
+      in_test_project(test_project_path, fn ->
+        Addons.TestEnv.apply(project)
+
+        assert_file("mix.exs", fn file ->
+          assert file =~ "aliases: aliases()"
+
+          assert file =~ """
+                   defp aliases do
+                     [
+                       codebase: [\"deps.unlock --check-unused\", \"format --check-formatted\"]
+                     ]
+                   end
+                 """
+        end)
+      end)
+    end
+
+    test "adds elixirc_paths", %{project: project, test_project_path: test_project_path} do
+      in_test_project(test_project_path, fn ->
+        Addons.TestEnv.apply(project)
+
+        assert_file("mix.exs", fn file ->
+          assert file =~ "elixirc_paths: elixirc_paths(Mix.env()),"
+
+          assert file =~ """
+                   # Specifies which paths to compile per environment.
+                   defp elixirc_paths(:test), do: ["lib", "test/support"]
+                   defp elixirc_paths(_), do: ["lib"]
+                 """
+        end)
+      end)
+    end
+
+    test "adds `Code.put_compiler_option(:warnings_as_errors, true)` into `test/test_helper.exs`",
+         %{project: project, test_project_path: test_project_path} do
+      in_test_project(test_project_path, fn ->
+        Addons.TestEnv.apply(project)
+
+        assert_file("test/test_helper.exs", fn file ->
+          assert file =~ """
+                 Code.put_compiler_option(:warnings_as_errors, true)
+
+                 ExUnit.start()
+                 """
+        end)
+      end)
+    end
+
+    test "sets line_length to 100 in .formatter.exs", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        Addons.TestEnv.apply(project)
+
+        assert_file(".formatter.exs", fn file ->
+          assert file =~ """
+                 [
+                   line_length: 100,
+                 """
+        end)
+      end)
+    end
+  end
 end

--- a/test/support/addon_case.ex
+++ b/test/support/addon_case.ex
@@ -30,14 +30,21 @@ defmodule Nimble.Phx.Gen.Template.AddonCase do
   end
 
   setup context do
-    # Set Web Project as default, switch to either API or Live Project in each test case
-    # eg: project = %{project | api_project?: true, web_project?: false}
-    project = Project.new(web: true)
-
     parent_test_project_path = Path.join(tmp_path(), parent_test_project_path())
     test_project_path = Path.join(parent_test_project_path, "/nimble_phx_gen_template")
 
-    create_test_project(test_project_path)
+    project =
+      if context[:mix_project?] == true do
+        create_mix_test_project(test_project_path)
+
+        Project.new(mix: true)
+      else
+        create_phoenix_test_project(test_project_path)
+
+        # Set Web Project as default, switch to either API or Live Project in each test case
+        # eg: project = %{project | api_project?: true, web_project?: false}
+        Project.new(web: true)
+      end
 
     on_exit(fn ->
       File.rm_rf!(parent_test_project_path)
@@ -59,10 +66,17 @@ defmodule Nimble.Phx.Gen.Template.AddonCase do
   defp mock_latest_package_version({_package, version}),
     do: expect(Package, :get_latest_version, fn _package -> version end)
 
-  defp create_test_project(test_project_path) do
+  defp create_phoenix_test_project(test_project_path) do
     # N - in response to Fetch and install dependencies?
     Mix.shell().cmd(
-      "printf \"N\n\" | make create_project PROJECT_DIRECTORY=#{test_project_path} > /dev/null"
+      "printf \"N\n\" | make create_phoenix_project PROJECT_DIRECTORY=#{test_project_path} > /dev/null"
+    )
+  end
+
+  defp create_mix_test_project(test_project_path) do
+    # N - in response to Fetch and install dependencies?
+    Mix.shell().cmd(
+      "printf \"N\n\" | make create_mix_project PROJECT_DIRECTORY=#{test_project_path} > /dev/null"
     )
   end
 


### PR DESCRIPTION
## What happened

Adding Mix variant #33 
 
## Insight

1/ Adding the `@moduledoc` into the mix task

2/ Supporting `--mix` option

3/ Supported addons

- ElixirVersion
- Readme
- TestEnv
- Credo
- Dialyxir
- ExCoveralls
- Github template and Github action workflow (optional)
- Mimic (optional)

4/ The mix task still as `nimble.phx.gen.template` so far, will rename the mix task on another PR.
 
## Proof Of Work

1/ Adding the `mix help nimble.phx.gen.template`

![image](https://user-images.githubusercontent.com/11751745/104145566-0ffb7800-53fa-11eb-9313-96f4666f36a1.png)

2/ The test is passed

3/ [Demo](https://drive.google.com/file/d/1ZwnT943WaJykga2svPAASZZP8yCaOp26/view?usp=sharing)