### PR TITLE
Validate the New Version to be Published on each Release branch

### DIFF
--- a/.github/workflows/test_release_version.yml
+++ b/.github/workflows/test_release_version.yml
@@ -1,0 +1,43 @@
+name: "Test Release version"
+
+on: push
+
+env:
+  OTP_VERSION: 23.1.4
+  ELIXIR_VERSION: 1.11.2
+  PHOENIX_VERSION: 1.5.7
+
+jobs:
+  release_version_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: actions/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - name: Install Dependencies
+        run: mix deps.get
+        
+      - name: Install Phoenix ${{ env.PHOENIX_VERSION }}
+        run: make install_phoenix PHOENIX_VERSION=${{ env.PHOENIX_VERSION }}
+          
+      - name: Run Tests
+        run: mix test --only release_version
+        env:
+          MIX_ENV: test

--- a/.github/workflows/test_release_version.yml
+++ b/.github/workflows/test_release_version.yml
@@ -1,6 +1,9 @@
 name: "Test Release version"
 
-on: push
+on:
+  pull_request:
+    branches:
+      - 'release/**'
 
 env:
   OTP_VERSION: 23.1.4

--- a/test/nimble.phx.gen.template/release_version_test.exs
+++ b/test/nimble.phx.gen.template/release_version_test.exs
@@ -1,0 +1,13 @@
+defmodule Nimble.Phx.Gen.Template.ReleaseVersionTest do
+  use ExUnit.Case, async: true
+
+  alias Nimble.Phx.Gen.Template.Hex.Package
+
+  @tag :release_version
+  test "the new version should be greater than the hex version" do
+    new_version = Mix.Project.config()[:version]
+    hex_version = Package.get_latest_version("nimble_phx_gen_template")
+
+    assert new_version > hex_version
+  end
+end

--- a/test/nimble.phx.gen.template/release_version_test.exs
+++ b/test/nimble.phx.gen.template/release_version_test.exs
@@ -4,7 +4,7 @@ defmodule Nimble.Phx.Gen.Template.ReleaseVersionTest do
   alias Nimble.Phx.Gen.Template.Hex.Package
 
   @tag :release_version
-  test "the new version should be greater than the hex version" do
+  test "the new version is greater than the hex version" do
     new_version = Mix.Project.config()[:version]
     hex_version = Package.get_latest_version("nimble_phx_gen_template")
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,3 +6,4 @@ Mimic.copy(Calendar)
 Mimic.copy(Nimble.Phx.Gen.Template.Hex.Package)
 
 ExUnit.start()
+ExUnit.configure(exclude: :release_version)


### PR DESCRIPTION
## What happened

Setup a test to check the new version to be published on each`release branches` should be greater than the `hex` version.

Solved https://github.com/nimblehq/elixir-templates/issues/68
 
## Insight

As the version number in the `mix.ex` file needs to be increased before releasing to Hex.pm **manually** so sometimes the developer could forget todo that.

In case the new version is the same with the hex version lower than it, hex.pm doesn't allow to publish the new version
 
## Proof Of Work

Try to trigger that workflow

![image](https://user-images.githubusercontent.com/11751745/102572788-8bca1380-411f-11eb-85ae-a204d5e81ce3.png)

