### PR TITLE
Update Installation part in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ end
 
 Then run `mix do deps.get, deps.compile` to install NimblePhxGenTemplate.
 
-*Note:* NimblePhxGenTemplate is only working on a new Phoenix project, applying NimblePhxGenTemplate to an existing Phoenix project might doesn't work as expected.
+*Note:* NimblePhxGenTemplate is only working on a new Phoenix project, applying NimblePhxGenTemplate to an existing Phoenix project might not work as expected.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ def deps do
 end
 ```
 
-Then run `mix do deps.get, deps.compile` to install NimblePhxGenTemplate
+Then run `mix do deps.get, deps.compile` to install NimblePhxGenTemplate.
+
+*Note:* NimblePhxGenTemplate is only working on a fresh new Phoenix project, applying NimblePhxGenTemplate to an existing Phoenix project might doesn't work as expected.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Project repository template to set up all public Phoenix projects at [Nimble](ht
 
 ## Installation
 
-### Generate a fresh new Phoenix project by using [mix phx.new](https://hexdocs.pm/phoenix/Mix.Tasks.Phx.New.html)
+### Generate a new Phoenix project by using [mix phx.new](https://hexdocs.pm/phoenix/Mix.Tasks.Phx.New.html)
 
 ```bash
 mix phx.new ...
@@ -23,7 +23,7 @@ end
 
 Then run `mix do deps.get, deps.compile` to install NimblePhxGenTemplate.
 
-*Note:* NimblePhxGenTemplate is only working on a fresh new Phoenix project, applying NimblePhxGenTemplate to an existing Phoenix project might doesn't work as expected.
+*Note:* NimblePhxGenTemplate is only working on a new Phoenix project, applying NimblePhxGenTemplate to an existing Phoenix project might doesn't work as expected.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,19 @@ Project repository template to set up all public Phoenix projects at [Nimble](ht
 
 ## Installation
 
-NimblePhxGenTemplate is published on Hex. Add it to your list of dependencies in `mix.exs`:
+### Generate a fresh new Phoenix project by using [mix phx.new](https://hexdocs.pm/phoenix/Mix.Tasks.Phx.New.html)
+
+```bash
+mix phx.new ...
+```
+
+### Adding `nimble_phx_gen_template` into `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:nimble_phx_gen_template, "~> 2.2.0", only: :dev, runtime: false}
+    {:nimble_phx_gen_template, "~> 2.2.0", only: :dev, runtime: false},
+    ...
   ]
 end
 ```


### PR DESCRIPTION
## What happened

Update the Installation part in README.
 
## Insight

Because the current template is only working on a new Phoenix project. Applying the template to an existing Phoenix project might doesn't work as expected for some addons.
 
## Proof Of Work

![image](https://user-images.githubusercontent.com/11751745/103601237-cf07ed00-4f3b-11eb-85d0-a3156ba70f07.png)

