### PR TITLE
Upgrade Erlang and Elixir versions

### DIFF
--- a/.github/workflows/publish_to_hex_pm.yml
+++ b/.github/workflows/publish_to_hex_pm.yml
@@ -11,8 +11,8 @@ on:
   workflow_dispatch:
 
 env:
-  OTP_VERSION: 23.1.4
-  ELIXIR_VERSION: 1.11.2
+  OTP_VERSION: 23.1.5
+  ELIXIR_VERSION: 1.11.3
 
 jobs:   
   publish:

--- a/.github/workflows/test_api_variant_on_custom_api_project.yml
+++ b/.github/workflows/test_api_variant_on_custom_api_project.yml
@@ -3,8 +3,8 @@ name: "Test API variant on custom API project"
 on: push
 
 env:
-  OTP_VERSION: 23.1.4
-  ELIXIR_VERSION: 1.11.2
+  OTP_VERSION: 23.1.5
+  ELIXIR_VERSION: 1.11.3
   PHOENIX_VERSION: 1.5.7
 
 jobs:   

--- a/.github/workflows/test_api_variant_on_standard_api_project.yml
+++ b/.github/workflows/test_api_variant_on_standard_api_project.yml
@@ -3,8 +3,8 @@ name: "Test API variant on standard API project"
 on: push
 
 env:
-  OTP_VERSION: 23.1.4
-  ELIXIR_VERSION: 1.11.2
+  OTP_VERSION: 23.1.5
+  ELIXIR_VERSION: 1.11.3
   PHOENIX_VERSION: 1.5.7
 
 jobs:   

--- a/.github/workflows/test_live_variant_on_custom_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_custom_liveview_project.yml
@@ -3,8 +3,8 @@ name: "Test Live variant on custom LiveView project"
 on: push
 
 env:
-  OTP_VERSION: 23.1.4
-  ELIXIR_VERSION: 1.11.2
+  OTP_VERSION: 23.1.5
+  ELIXIR_VERSION: 1.11.3
   PHOENIX_VERSION: 1.5.7
   NODE_VERSION: 14
 

--- a/.github/workflows/test_live_variant_on_standard_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_standard_liveview_project.yml
@@ -3,8 +3,8 @@ name: "Test Live variant on standard LiveView project"
 on: push
 
 env:
-  OTP_VERSION: 23.1.4
-  ELIXIR_VERSION: 1.11.2
+  OTP_VERSION: 23.1.5
+  ELIXIR_VERSION: 1.11.3
   PHOENIX_VERSION: 1.5.7
   NODE_VERSION: 14
 

--- a/.github/workflows/test_release_version.yml
+++ b/.github/workflows/test_release_version.yml
@@ -6,8 +6,8 @@ on:
       - 'release/**'
 
 env:
-  OTP_VERSION: 23.1.4
-  ELIXIR_VERSION: 1.11.2
+  OTP_VERSION: 23.1.5
+  ELIXIR_VERSION: 1.11.3
   PHOENIX_VERSION: 1.5.7
 
 jobs:

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -3,8 +3,8 @@ name: "Test template"
 on: push
 
 env:
-  OTP_VERSION: 23.1.4
-  ELIXIR_VERSION: 1.11.2
+  OTP_VERSION: 23.1.5
+  ELIXIR_VERSION: 1.11.3
   PHOENIX_VERSION: 1.5.7
 
 jobs:

--- a/.github/workflows/test_variant_on_custom_project.yml
+++ b/.github/workflows/test_variant_on_custom_project.yml
@@ -3,8 +3,8 @@ name: "Test variant on custom Web project"
 on: push
 
 env:
-  OTP_VERSION: 23.1.4
-  ELIXIR_VERSION: 1.11.2
+  OTP_VERSION: 23.1.5
+  ELIXIR_VERSION: 1.11.3
   PHOENIX_VERSION: 1.5.7
   NODE_VERSION: 14
 

--- a/.github/workflows/test_variant_on_standard_project.yml
+++ b/.github/workflows/test_variant_on_standard_project.yml
@@ -3,8 +3,8 @@ name: "Test variant on standard Web project"
 on: push
 
 env:
-  OTP_VERSION: 23.1.4
-  ELIXIR_VERSION: 1.11.2
+  OTP_VERSION: 23.1.5
+  ELIXIR_VERSION: 1.11.3
   PHOENIX_VERSION: 1.5.7
   NODE_VERSION: 14
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 23.1.4
-elixir 1.11.2-otp-23
+erlang 23.1.5
+elixir 1.11.3-otp-23

--- a/lib/nimble.phx.gen.template/project.ex
+++ b/lib/nimble.phx.gen.template/project.ex
@@ -2,14 +2,14 @@ defmodule Nimble.Phx.Gen.Template.Project do
   # Erlang versions: asdf list all erlang
   # Elixir versions: asdf list all elixir
   @default_versions %{
-    erlang_asdf_version: "23.1.4",
-    elixir_asdf_version: "1.11.2-otp-23",
+    erlang_asdf_version: "23.1.5",
+    elixir_asdf_version: "1.11.3-otp-23",
     elixir_mix_version: "1.11"
   }
 
   # Elixir image tags: https://hub.docker.com/r/hexpm/elixir/tags
   @docker_base_images %{
-    build: "hexpm/elixir:1.11.2-erlang-23.1.4-alpine-3.12.1",
+    build: "hexpm/elixir:1.11.3-erlang-23.1.5-alpine-3.12.1",
     app: "alpine:3.12.1"
   }
 

--- a/test/nimble.phx.gen.template/addons/docker_test.exs
+++ b/test/nimble.phx.gen.template/addons/docker_test.exs
@@ -57,7 +57,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.DockerTest do
         Addons.Docker.apply(project)
 
         assert_file("Dockerfile", fn file ->
-          assert file =~ "FROM hexpm/elixir:1.11.2-erlang-23.1.4-alpine-3.12.1 AS build"
+          assert file =~ "FROM hexpm/elixir:1.11.3-erlang-23.1.5-alpine-3.12.1 AS build"
           assert file =~ "FROM alpine:3.12.1 AS app"
 
           assert file =~

--- a/test/nimble.phx.gen.template/addons/elixir_version_test.exs
+++ b/test/nimble.phx.gen.template/addons/elixir_version_test.exs
@@ -11,8 +11,8 @@ defmodule Nimble.Phx.Gen.Template.Addons.ElixirVersionTest do
 
         assert_file(".tool-versions", fn file ->
           assert file =~ """
-                 erlang 23.1.4
-                 elixir 1.11.2-otp-23
+                 erlang 23.1.5
+                 elixir 1.11.3-otp-23
                  """
         end)
       end)

--- a/test/nimble.phx.gen.template/addons/readme_test.exs
+++ b/test/nimble.phx.gen.template/addons/readme_test.exs
@@ -11,7 +11,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.ReadmeTest do
 
         assert_file("README.md", fn file ->
           assert file =~ """
-                 Erlang 23.1.4+ and Elixir 1.11+
+                 Erlang 23.1.5+ and Elixir 1.11+
                  """
 
           assert file =~ """
@@ -38,7 +38,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.ReadmeTest do
 
         assert_file("README.md", fn file ->
           assert file =~ """
-                 Erlang 23.1.4+ and Elixir 1.11+
+                 Erlang 23.1.5+ and Elixir 1.11+
                  """
 
           refute file =~ """


### PR DESCRIPTION
## What happened

Upgrade Erlang and Elixir to latest version before release 2.2.0
 
## Insight

- Erlang: 23.1.5
- Elixir: 1.11.3
