### PR TITLE
Test Release version workflow is not triggered on release branch

### DIFF
--- a/.github/workflows/test_release_version.yml
+++ b/.github/workflows/test_release_version.yml
@@ -1,7 +1,7 @@
 name: "Test Release version"
 
 on:
-  pull_request:
+  push:
     branches:
       - 'release/**'
 


### PR DESCRIPTION
## What happened

Test Release version workflow is not triggered on the release branch https://github.com/nimblehq/elixir-templates/pull/75
 
## Insight

- Relative PR https://github.com/nimblehq/elixir-templates/pull/71
- Have to change from `pull_request` event to `push` event because the `pull_request` triggers the `PR` that against the `release/**` branches 😁   it's opposite what we are looking.

