### PR TITLE
Refactor the default version component

### DIFF
--- a/.github/workflows/publish_to_hex_pm.yml
+++ b/.github/workflows/publish_to_hex_pm.yml
@@ -11,8 +11,8 @@ on:
   workflow_dispatch:
 
 env:
-  OTP_VERSION: 23.2.1
-  ELIXIR_VERSION: 1.11.3
+  OTP_VERSION: 23.3
+  ELIXIR_VERSION: 1.11.4
 
 jobs:   
   publish:

--- a/.github/workflows/test_api_variant_on_custom_api_project.yml
+++ b/.github/workflows/test_api_variant_on_custom_api_project.yml
@@ -3,8 +3,8 @@ name: "Test API variant on custom API project"
 on: push
 
 env:
-  OTP_VERSION: 23.2.1
-  ELIXIR_VERSION: 1.11.3
+  OTP_VERSION: 23.3
+  ELIXIR_VERSION: 1.11.4
   PHOENIX_VERSION: 1.5.7
 
 jobs:   

--- a/.github/workflows/test_api_variant_on_standard_api_project.yml
+++ b/.github/workflows/test_api_variant_on_standard_api_project.yml
@@ -3,8 +3,8 @@ name: "Test API variant on standard API project"
 on: push
 
 env:
-  OTP_VERSION: 23.2.1
-  ELIXIR_VERSION: 1.11.3
+  OTP_VERSION: 23.3
+  ELIXIR_VERSION: 1.11.4
   PHOENIX_VERSION: 1.5.7
 
 jobs:   

--- a/.github/workflows/test_live_variant_on_custom_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_custom_liveview_project.yml
@@ -3,8 +3,8 @@ name: "Test Live variant on custom LiveView project"
 on: push
 
 env:
-  OTP_VERSION: 23.2.1
-  ELIXIR_VERSION: 1.11.3
+  OTP_VERSION: 23.3
+  ELIXIR_VERSION: 1.11.4
   PHOENIX_VERSION: 1.5.7
   NODE_VERSION: 14
 

--- a/.github/workflows/test_live_variant_on_custom_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_custom_liveview_project.yml
@@ -34,7 +34,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
         
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ env.NODE_VERSION }}
           

--- a/.github/workflows/test_live_variant_on_standard_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_standard_liveview_project.yml
@@ -34,7 +34,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
           
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ env.NODE_VERSION }}
           

--- a/.github/workflows/test_live_variant_on_standard_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_standard_liveview_project.yml
@@ -3,8 +3,8 @@ name: "Test Live variant on standard LiveView project"
 on: push
 
 env:
-  OTP_VERSION: 23.2.1
-  ELIXIR_VERSION: 1.11.3
+  OTP_VERSION: 23.3
+  ELIXIR_VERSION: 1.11.4
   PHOENIX_VERSION: 1.5.7
   NODE_VERSION: 14
 

--- a/.github/workflows/test_release_version.yml
+++ b/.github/workflows/test_release_version.yml
@@ -6,8 +6,8 @@ on:
       - 'release/**'
 
 env:
-  OTP_VERSION: 23.2.1
-  ELIXIR_VERSION: 1.11.3
+  OTP_VERSION: 23.3
+  ELIXIR_VERSION: 1.11.4
   PHOENIX_VERSION: 1.5.7
 
 jobs:

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -3,8 +3,8 @@ name: "Test template"
 on: push
 
 env:
-  OTP_VERSION: 23.2.1
-  ELIXIR_VERSION: 1.11.3
+  OTP_VERSION: 23.3
+  ELIXIR_VERSION: 1.11.4
   PHOENIX_VERSION: 1.5.7
 
 jobs:

--- a/.github/workflows/test_variant_on_custom_project.yml
+++ b/.github/workflows/test_variant_on_custom_project.yml
@@ -38,7 +38,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
     
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ env.NODE_VERSION }}
           

--- a/.github/workflows/test_variant_on_custom_project.yml
+++ b/.github/workflows/test_variant_on_custom_project.yml
@@ -3,8 +3,8 @@ name: "Test variant on custom Web project"
 on: push
 
 env:
-  OTP_VERSION: 23.2.1
-  ELIXIR_VERSION: 1.11.3
+  OTP_VERSION: 23.3
+  ELIXIR_VERSION: 1.11.4
   PHOENIX_VERSION: 1.5.7
   NODE_VERSION: 14
 

--- a/.github/workflows/test_variant_on_standard_project.yml
+++ b/.github/workflows/test_variant_on_standard_project.yml
@@ -38,7 +38,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
     
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ env.NODE_VERSION }}
           

--- a/.github/workflows/test_variant_on_standard_project.yml
+++ b/.github/workflows/test_variant_on_standard_project.yml
@@ -3,8 +3,8 @@ name: "Test variant on standard Web project"
 on: push
 
 env:
-  OTP_VERSION: 23.2.1
-  ELIXIR_VERSION: 1.11.3
+  OTP_VERSION: 23.3
+  ELIXIR_VERSION: 1.11.4
   PHOENIX_VERSION: 1.5.7
   NODE_VERSION: 14
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 23.2.1
-elixir 1.11.3-otp-23
+erlang 23.3
+elixir 1.11.4-otp-23

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Phoenix template for projects at [Nimble](https://nimblehq.co/).
 
 NimblePhxGenTemplate has been developed and actively tested with the below environment:
 
-- Elixir 1.11.3
-- Erlang/OTP 23.2.1
+- Elixir 1.11.4
+- Erlang/OTP 23.3
 - Phoenix 1.5.7
 
 ## Installation
@@ -173,4 +173,3 @@ See [our other projects][community] or [hire our team][hire] to help build your 
 
 [community]: https://github.com/nimblehq
 [hire]: https://nimblehq.co
-

--- a/lib/nimble.phx.gen.template/addons/elixir_version.ex
+++ b/lib/nimble.phx.gen.template/addons/elixir_version.ex
@@ -2,16 +2,13 @@ defmodule Nimble.Phx.Gen.Template.Addons.ElixirVersion do
   use Nimble.Phx.Gen.Template.Addon
 
   @impl true
-  def do_apply(%Project{} = project, _opts) do
-    copy_files(project)
-  end
-
-  defp copy_files(
-         %Project{
-           erlang_version: erlang_version,
-           elixir_asdf_version: elixir_asdf_version
-         } = project
-       ) do
+  def do_apply(
+        %Project{
+          erlang_version: erlang_version,
+          elixir_asdf_version: elixir_asdf_version
+        } = project,
+        _opts
+      ) do
     Generator.copy_file([{:eex, ".tool-versions.eex", ".tool-versions"}],
       erlang_version: erlang_version,
       elixir_asdf_version: elixir_asdf_version

--- a/lib/nimble.phx.gen.template/addons/elixir_version.ex
+++ b/lib/nimble.phx.gen.template/addons/elixir_version.ex
@@ -3,34 +3,18 @@ defmodule Nimble.Phx.Gen.Template.Addons.ElixirVersion do
 
   @impl true
   def do_apply(%Project{} = project, _opts) do
-    project
-    |> copy_files()
-    |> edit_files()
+    copy_files(project)
   end
 
   defp copy_files(
          %Project{
-           erlang_asdf_version: erlang_asdf_version,
+           erlang_version: erlang_version,
            elixir_asdf_version: elixir_asdf_version
          } = project
        ) do
     Generator.copy_file([{:eex, ".tool-versions.eex", ".tool-versions"}],
-      erlang_asdf_version: erlang_asdf_version,
+      erlang_version: erlang_version,
       elixir_asdf_version: elixir_asdf_version
-    )
-
-    project
-  end
-
-  defp edit_files(%Project{elixir_mix_version: elixir_mix_version} = project) do
-    Generator.replace_content(
-      "mix.exs",
-      """
-            elixir: "~> 1.7",
-      """,
-      """
-            elixir: "~> #{elixir_mix_version}",
-      """
     )
 
     project

--- a/lib/nimble.phx.gen.template/addons/github.ex
+++ b/lib/nimble.phx.gen.template/addons/github.ex
@@ -1,11 +1,6 @@
 defmodule Nimble.Phx.Gen.Template.Addons.Github do
   use Nimble.Phx.Gen.Template.Addon
 
-  @versions %{
-    otp_version: "23.0.2",
-    elixir_version: "1.10.4"
-  }
-
   @impl true
   def do_apply(%Project{} = project, opts) when is_map_key(opts, :github_template) do
     files = [
@@ -21,11 +16,18 @@ defmodule Nimble.Phx.Gen.Template.Addons.Github do
   end
 
   @impl true
-  def do_apply(%Project{web_project?: web_project?} = project, opts)
+  def do_apply(
+        %Project{
+          web_project?: web_project?,
+          erlang_version: erlang_version,
+          elixir_version: elixir_version
+        } = project,
+        opts
+      )
       when is_map_key(opts, :github_action) do
     binding = [
-      otp_version: @versions.otp_version,
-      elixir_version: @versions.elixir_version,
+      erlang_version: erlang_version,
+      elixir_version: elixir_version,
       web_project?: web_project?
     ]
 

--- a/lib/nimble.phx.gen.template/addons/github.ex
+++ b/lib/nimble.phx.gen.template/addons/github.ex
@@ -20,7 +20,8 @@ defmodule Nimble.Phx.Gen.Template.Addons.Github do
         %Project{
           web_project?: web_project?,
           erlang_version: erlang_version,
-          elixir_version: elixir_version
+          elixir_version: elixir_version,
+          node_version: node_version
         } = project,
         opts
       )
@@ -28,6 +29,7 @@ defmodule Nimble.Phx.Gen.Template.Addons.Github do
     binding = [
       erlang_version: erlang_version,
       elixir_version: elixir_version,
+      node_version: node_version,
       web_project?: web_project?
     ]
 

--- a/lib/nimble.phx.gen.template/addons/readme.ex
+++ b/lib/nimble.phx.gen.template/addons/readme.ex
@@ -17,13 +17,13 @@ defmodule Nimble.Phx.Gen.Template.Addons.Readme do
   defp copy_files(
          %Project{
            api_project?: api_project?,
-           erlang_asdf_version: erlang_asdf_version,
-           elixir_mix_version: elixir_mix_version
+           erlang_version: erlang_version,
+           elixir_version: elixir_version
          } = project
        ) do
     Generator.copy_file([{:eex, "README.md.eex", "README.md"}],
-      erlang_version: erlang_asdf_version,
-      elixir_version: elixir_mix_version,
+      erlang_version: erlang_version,
+      elixir_version: elixir_version,
       web_project?: !api_project?
     )
 

--- a/lib/nimble.phx.gen.template/project.ex
+++ b/lib/nimble.phx.gen.template/project.ex
@@ -1,17 +1,8 @@
 defmodule Nimble.Phx.Gen.Template.Project do
-  # Erlang versions: asdf list all erlang
-  # Elixir versions: asdf list all elixir
-  @default_versions %{
-    erlang_asdf_version: "23.2.1",
-    elixir_asdf_version: "1.11.3-otp-23",
-    elixir_mix_version: "1.11.3"
-  }
+  @elixir_version "1.11.3"
+  @erlang_version "23.2.1"
 
-  # Elixir image tags: https://hub.docker.com/r/hexpm/elixir/tags
-  @docker_base_images %{
-    build: "hexpm/elixir:1.11.3-erlang-23.2.1-alpine-3.12.1",
-    app: "alpine:3.12.1"
-  }
+  @alpine_version "3.12.1"
 
   defstruct otp_app: nil,
             base_module: nil,
@@ -23,11 +14,13 @@ defmodule Nimble.Phx.Gen.Template.Project do
             api_project?: false,
             web_project?: false,
             live_project?: false,
-            erlang_asdf_version: @default_versions[:erlang_asdf_version],
-            elixir_asdf_version: @default_versions[:elixir_asdf_version],
-            elixir_mix_version: @default_versions[:elixir_mix_version],
-            docker_build_base_image: @docker_base_images[:build],
-            docker_app_base_image: @docker_base_images[:app]
+            elixir_mix_version: @elixir_version,
+            erlang_asdf_version: @erlang_version,
+            elixir_asdf_version:
+              "#{@elixir_version}-otp-#{@erlang_version |> String.split(".") |> List.first()}",
+            docker_build_base_image:
+              "hexpm/elixir:#{@elixir_version}-erlang-#{@erlang_version}-alpine-#{@alpine_version}",
+            docker_app_base_image: "alpine:#{@alpine_version}"
 
   def new(opts \\ %{}) do
     %__MODULE__{

--- a/lib/nimble.phx.gen.template/project.ex
+++ b/lib/nimble.phx.gen.template/project.ex
@@ -1,6 +1,7 @@
 defmodule Nimble.Phx.Gen.Template.Project do
   @elixir_version "1.11.3"
   @erlang_version "23.2.1"
+  @node_version "14"
 
   @alpine_version "3.12.1"
 
@@ -16,6 +17,7 @@ defmodule Nimble.Phx.Gen.Template.Project do
             live_project?: false,
             elixir_version: @elixir_version,
             erlang_version: @erlang_version,
+            node_version: @node_version,
             elixir_asdf_version:
               "#{@elixir_version}-otp-#{@erlang_version |> String.split(".") |> List.first()}",
             docker_build_base_image:

--- a/lib/nimble.phx.gen.template/project.ex
+++ b/lib/nimble.phx.gen.template/project.ex
@@ -14,8 +14,8 @@ defmodule Nimble.Phx.Gen.Template.Project do
             api_project?: false,
             web_project?: false,
             live_project?: false,
-            elixir_mix_version: @elixir_version,
-            erlang_asdf_version: @erlang_version,
+            elixir_version: @elixir_version,
+            erlang_version: @erlang_version,
             elixir_asdf_version:
               "#{@elixir_version}-otp-#{@erlang_version |> String.split(".") |> List.first()}",
             docker_build_base_image:

--- a/lib/nimble.phx.gen.template/project.ex
+++ b/lib/nimble.phx.gen.template/project.ex
@@ -5,37 +5,39 @@ defmodule Nimble.Phx.Gen.Template.Project do
 
   @alpine_version "3.12.1"
 
-  defstruct otp_app: nil,
-            base_module: nil,
+  defstruct base_module: nil,
             base_path: nil,
             base_test_path: nil,
+            otp_app: nil,
             web_module: nil,
             web_path: nil,
             web_test_path: nil,
-            api_project?: false,
-            web_project?: false,
-            live_project?: false,
-            elixir_version: @elixir_version,
-            erlang_version: @erlang_version,
-            node_version: @node_version,
-            elixir_asdf_version:
-              "#{@elixir_version}-otp-#{@erlang_version |> String.split(".") |> List.first()}",
+            # Dependency Versions
+            docker_app_base_image: "alpine:#{@alpine_version}",
             docker_build_base_image:
               "hexpm/elixir:#{@elixir_version}-erlang-#{@erlang_version}-alpine-#{@alpine_version}",
-            docker_app_base_image: "alpine:#{@alpine_version}"
+            elixir_version: @elixir_version,
+            elixir_asdf_version:
+              "#{@elixir_version}-otp-#{@erlang_version |> String.split(".") |> List.first()}",
+            erlang_version: @erlang_version,
+            node_version: @node_version,
+            # Variants
+            api_project?: false,
+            live_project?: false,
+            web_project?: false
 
   def new(opts \\ %{}) do
     %__MODULE__{
-      api_project?: api_project?(opts),
-      web_project?: web_project?(opts),
-      live_project?: live_project?(opts),
-      otp_app: otp_app(),
       base_module: base_module(),
       base_path: "lib/" <> Atom.to_string(otp_app()),
       base_test_path: "test/" <> Atom.to_string(otp_app()),
+      otp_app: otp_app(),
       web_module: base_module() <> "Web",
       web_path: "lib/" <> Atom.to_string(otp_app()) <> "_web",
-      web_test_path: "test/" <> Atom.to_string(otp_app()) <> "_web"
+      web_test_path: "test/" <> Atom.to_string(otp_app()) <> "_web",
+      api_project?: api_project?(opts),
+      web_project?: web_project?(opts),
+      live_project?: live_project?(opts)
     }
   end
 

--- a/lib/nimble.phx.gen.template/project.ex
+++ b/lib/nimble.phx.gen.template/project.ex
@@ -1,9 +1,9 @@
 defmodule Nimble.Phx.Gen.Template.Project do
-  @elixir_version "1.11.3"
-  @erlang_version "23.2.1"
+  @elixir_version "1.11.4"
+  @erlang_version "23.3"
   @node_version "14"
 
-  @alpine_version "3.12.1"
+  @alpine_version "3.13.2"
 
   defstruct base_module: nil,
             base_path: nil,

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule NimblePhxGenTemplate.MixProject do
       app: :nimble_phx_gen_template,
       version: "2.2.1",
       description: "Project repository template to set up all public Phoenix projects at Nimble",
-      elixir: "~> 1.11.3",
+      elixir: "~> 1.11.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/priv/templates/nimble.phx.gen.template/.github/workflows/test.yml.eex
+++ b/priv/templates/nimble.phx.gen.template/.github/workflows/test.yml.eex
@@ -5,6 +5,7 @@ on: pull_request
 env:
   OTP_VERSION: <%= inspect erlang_version %>
   ELIXIR_VERSION: <%= inspect elixir_version %>
+  NODE_VERSION: <%= inspect node_version %>
 
 jobs:
   test:
@@ -31,7 +32,11 @@ jobs:
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
-
+      <%= if web_project? do %>
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      <% end %>
       - name: Cache Elixir build
         uses: actions/cache@v2
         with:

--- a/priv/templates/nimble.phx.gen.template/.github/workflows/test.yml.eex
+++ b/priv/templates/nimble.phx.gen.template/.github/workflows/test.yml.eex
@@ -1,8 +1,9 @@
 name: "Tests"
+
 on: pull_request
 
 env:
-  OTP_VERSION: <%= inspect otp_version %>
+  OTP_VERSION: <%= inspect erlang_version %>
   ELIXIR_VERSION: <%= inspect elixir_version %>
 
 jobs:

--- a/priv/templates/nimble.phx.gen.template/.github/workflows/test.yml.eex
+++ b/priv/templates/nimble.phx.gen.template/.github/workflows/test.yml.eex
@@ -33,7 +33,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
       <%= if web_project? do %>
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ env.NODE_VERSION }}
       <% end %>

--- a/priv/templates/nimble.phx.gen.template/.tool-versions.eex
+++ b/priv/templates/nimble.phx.gen.template/.tool-versions.eex
@@ -1,3 +1,3 @@
 # Configuration file for https://github.com/asdf-vm/asdf
-erlang <%= erlang_asdf_version %>
+erlang <%= erlang_version %>
 elixir <%= elixir_asdf_version %>

--- a/priv/templates/nimble.phx.gen.template/README.md.eex
+++ b/priv/templates/nimble.phx.gen.template/README.md.eex
@@ -8,11 +8,15 @@
 
 ### Erlang & Elixir
 
-* Erlang <%= erlang_version %> and Elixir <%= elixir_version %>
+* Erlang <%= erlang_version %>
+
+* Elixir <%= elixir_version %>
 
 * Recommended version manager.
 
-  - [asdf](https://github.com/asdf-vm/asdf) Erlang & Elixir
+  - [asdf](https://github.com/asdf-vm/asdf)
+  - [asdf-erlang](https://github.com/asdf-vm/asdf-erlang)
+  - [asdf-elixir](https://github.com/asdf-vm/asdf-elixir)
 
 ### Development
 
@@ -58,6 +62,12 @@
 
   ```sh
   mix codebase 
+  ```
+  
+* Test coverage:
+
+  ```sh
+  mix coverage 
   ```
 
 ### Production

--- a/priv/templates/nimble.phx.gen.template/test/support/factory.ex.eex
+++ b/priv/templates/nimble.phx.gen.template/test/support/factory.ex.eex
@@ -2,5 +2,5 @@ defmodule <%= base_module %>.Factory do
   use ExMachina.Ecto, repo: <%= base_module %>.Repo
 
   # Define your factories in /test/factories and declare it here,
-  # eg: `use <%base_module %>.Accounts.UserFactory`
+  # eg: `use <%= base_module %>.Accounts.UserFactory`
 end

--- a/test/nimble.phx.gen.template/addons/docker_test.exs
+++ b/test/nimble.phx.gen.template/addons/docker_test.exs
@@ -57,8 +57,8 @@ defmodule Nimble.Phx.Gen.Template.Addons.DockerTest do
         Addons.Docker.apply(project)
 
         assert_file("Dockerfile", fn file ->
-          assert file =~ "FROM hexpm/elixir:1.11.3-erlang-23.2.1-alpine-3.12.1 AS build"
-          assert file =~ "FROM alpine:3.12.1 AS app"
+          assert file =~ "FROM hexpm/elixir:1.11.4-erlang-23.3-alpine-3.13.2 AS build"
+          assert file =~ "FROM alpine:3.13.2 AS app"
 
           assert file =~
                    "RUN npm --prefix ./assets ci --progress=false --no-audit --loglevel=error"

--- a/test/nimble.phx.gen.template/addons/elixir_version_test.exs
+++ b/test/nimble.phx.gen.template/addons/elixir_version_test.exs
@@ -17,18 +17,5 @@ defmodule Nimble.Phx.Gen.Template.Addons.ElixirVersionTest do
         end)
       end)
     end
-
-    test "changes the minimum Elixir version", %{
-      project: project,
-      test_project_path: test_project_path
-    } do
-      in_test_project(test_project_path, fn ->
-        Addons.ElixirVersion.apply(project)
-
-        assert_file("mix.exs", fn file ->
-          assert file =~ "elixir: \"~> 1.11.3\","
-        end)
-      end)
-    end
   end
 end

--- a/test/nimble.phx.gen.template/addons/elixir_version_test.exs
+++ b/test/nimble.phx.gen.template/addons/elixir_version_test.exs
@@ -11,8 +11,8 @@ defmodule Nimble.Phx.Gen.Template.Addons.ElixirVersionTest do
 
         assert_file(".tool-versions", fn file ->
           assert file =~ """
-                 erlang 23.2.1
-                 elixir 1.11.3-otp-23
+                 erlang 23.3
+                 elixir 1.11.4-otp-23
                  """
         end)
       end)

--- a/test/nimble.phx.gen.template/addons/readme_test.exs
+++ b/test/nimble.phx.gen.template/addons/readme_test.exs
@@ -10,9 +10,8 @@ defmodule Nimble.Phx.Gen.Template.Addons.ReadmeTest do
         Addons.Readme.apply(project)
 
         assert_file("README.md", fn file ->
-          assert file =~ """
-                 Erlang 23.2.1 and Elixir 1.11.3
-                 """
+          assert file =~ "Erlang 23.2.1"
+          assert file =~ "Elixir 1.11.3"
 
           assert file =~ """
                  * Install Node dependencies:
@@ -37,9 +36,8 @@ defmodule Nimble.Phx.Gen.Template.Addons.ReadmeTest do
         Addons.Readme.apply(project)
 
         assert_file("README.md", fn file ->
-          assert file =~ """
-                 Erlang 23.2.1 and Elixir 1.11.3
-                 """
+          assert file =~ "Erlang 23.2.1"
+          assert file =~ "Elixir 1.11.3"
 
           refute file =~ """
                  * Install Node dependencies:

--- a/test/nimble.phx.gen.template/addons/readme_test.exs
+++ b/test/nimble.phx.gen.template/addons/readme_test.exs
@@ -10,8 +10,8 @@ defmodule Nimble.Phx.Gen.Template.Addons.ReadmeTest do
         Addons.Readme.apply(project)
 
         assert_file("README.md", fn file ->
-          assert file =~ "Erlang 23.2.1"
-          assert file =~ "Elixir 1.11.3"
+          assert file =~ "Erlang 23.3"
+          assert file =~ "Elixir 1.11.4"
 
           assert file =~ """
                  * Install Node dependencies:
@@ -36,8 +36,8 @@ defmodule Nimble.Phx.Gen.Template.Addons.ReadmeTest do
         Addons.Readme.apply(project)
 
         assert_file("README.md", fn file ->
-          assert file =~ "Erlang 23.2.1"
-          assert file =~ "Elixir 1.11.3"
+          assert file =~ "Erlang 23.3"
+          assert file =~ "Elixir 1.11.4"
 
           refute file =~ """
                  * Install Node dependencies:


### PR DESCRIPTION
## What happened

Simplify the `default versions` so, in the future, we just need to update either `@elixir_version` or `@erlang_version` or `@alpine_version`
 
## Insight

1/ Simplify the `default versions` so, in the future, we just need to update either `@elixir_version` or `@erlang_version` or `@alpine_version`
2/ Refactor the Github Action Elixir, Erlang and Node version
3/ Upgrade Elixir to 1.11.4 and Erlang to 23.3
 
## Proof Of Work

The test is GREEN on CI
