### PR TITLE
Adding Github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -1,0 +1,20 @@
+---
+name: "Bug Report"
+about: "You found something that is not working. Report it so that it can be fixed. 👷‍"
+title: "Fix: "
+labels: "type : bug"
+---
+
+## Issue
+
+Describe the issue you are facing. Show us the implementation: screenshots, gif, etc.
+ 
+## Expected
+
+Describe what should be the correct behaviour.
+ 
+## Steps to reproduce
+
+1. 
+2. 
+3. 

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -1,0 +1,14 @@
+---
+name: "Feature"
+about: "Open a feature issue to add new functionalities."
+title: "Add "
+labels: "type : feature"
+---
+
+## Why
+
+Describe the big picture of the feature and why it's needed. 
+
+## Who Benefits?
+
+Describe who will be the beneficiaries e.g. everyone, clients...

--- a/.github/ISSUE_TEMPLATE/rfc_template.md
+++ b/.github/ISSUE_TEMPLATE/rfc_template.md
@@ -1,0 +1,28 @@
+---
+name: "Request For Comments (RFC)"
+about: "You have an idea on how to improve the template. Propose your idea so that the team can provide feedback."
+title: "RFC: "
+labels: "type : rfa"
+---
+
+## Issue
+
+Describe the issue from the template or generated project currently facing. Provide as much content as possible.
+
+## Solution
+
+Describe the solution you are prescribing for the issue.
+
+## Who Benefits?
+
+Describe who will be the beneficiaries e.g. everyone, clients...
+
+## What's Next?
+
+Provide an actionable list of things that must happen in order to implement the solution:
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+Using a poll is encouraged to gather feedback on the RFA 👉 Use this tool: https://gh-polls.com/


### PR DESCRIPTION
## What happened

Add following Github issue templates:

- Bug Report
- Feature
- RFC

The template content is taken from [compass](https://github.com/nimblehq/compass/issues/new/choose) and update content to make it more related to this template.
