### PR TITLE
Refactor the variant folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,18 +81,19 @@ All test files are located under `test/` directory.
 │   │   │   ├── ...
 │   │   │   ├── common_addon_test.exs
 │   │   │   └── variants
-│   │   │   │   └── api
-│   │   │   │   │   ├── ...
-│   │   │   │   │   └── api_addon_test.exs
-│   │   │   │   └── live
-│   │   │   │   │   ├── ...
-│   │   │   │   │   └── live_addon_test.exs
 │   │   │   │   └── mix
 │   │   │   │   │   ├── ...
 │   │   │   │   │   └── mix_addon_test.exs
-│   │   │   │   └── web
-│   │   │   │   │   ├── ...
-│   │   │   │   │   └── web_addon_test.exs
+│   │   │   │   └── phoenix
+│   │   │   │   │   └── api
+│   │   │   │   │   │   ├── ...
+│   │   │   │   │   │   └── api_addon_test.exs
+│   │   │   │   │   └── live
+│   │   │   │   │   │   ├── ...
+│   │   │   │   │   │   └── live_addon_test.exs
+│   │   │   │   │   └── web
+│   │   │   │   │   │   ├── ...
+│   │   │   │   │   │   └── web_addon_test.exs
 ```
 
 ### 2/ Variant test

--- a/lib/nimble_template/addons/variants/phoenix/web/assets.ex
+++ b/lib/nimble_template/addons/variants/phoenix/web/assets.ex
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.Web.Assets do
+defmodule NimbleTemplate.Addons.Phoenix.Web.Assets do
   @moduledoc false
 
   use NimbleTemplate.Addon

--- a/lib/nimble_template/addons/variants/phoenix/web/core_js.ex
+++ b/lib/nimble_template/addons/variants/phoenix/web/core_js.ex
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.Web.CoreJS do
+defmodule NimbleTemplate.Addons.Phoenix.Web.CoreJS do
   @moduledoc false
 
   use NimbleTemplate.Addon

--- a/lib/nimble_template/addons/variants/phoenix/web/sobelow.ex
+++ b/lib/nimble_template/addons/variants/phoenix/web/sobelow.ex
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.Web.Sobelow do
+defmodule NimbleTemplate.Addons.Phoenix.Web.Sobelow do
   @moduledoc false
 
   use NimbleTemplate.Addon

--- a/lib/nimble_template/addons/variants/phoenix/web/wallaby.ex
+++ b/lib/nimble_template/addons/variants/phoenix/web/wallaby.ex
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.Web.Wallaby do
+defmodule NimbleTemplate.Addons.Phoenix.Web.Wallaby do
   @moduledoc false
 
   use NimbleTemplate.Addon

--- a/lib/nimble_template/template.ex
+++ b/lib/nimble_template/template.ex
@@ -1,24 +1,20 @@
 defmodule NimbleTemplate.Template do
   @moduledoc false
 
-  alias NimbleTemplate.Api.Template, as: ApiTemplate
-  alias NimbleTemplate.Live.Template, as: LiveTemplate
   alias NimbleTemplate.Mix.Template, as: MixTemplate
-  alias NimbleTemplate.Web.Template, as: WebTemplate
+  alias NimbleTemplate.Phoenix.Template, as: PhoenixTemplate
   alias NimbleTemplate.{Addons, Project}
 
   def apply(%Project{mix_project?: true} = project) do
     MixTemplate.apply(project)
 
-    if Mix.shell().yes?("\nFetch and install dependencies?"), do: Mix.shell().cmd("mix deps.get")
+    fetch_and_install_dependencies()
   end
 
   def apply(%Project{} = project) do
-    project
-    |> common_setup()
-    |> variant_setup()
+    PhoenixTemplate.apply(project)
 
-    if Mix.shell().yes?("\nFetch and install dependencies?"), do: Mix.shell().cmd("mix deps.get")
+    fetch_and_install_dependencies()
   end
 
   def host_on_github?(), do: Mix.shell().yes?("\nWill you host this project on Github?")
@@ -35,40 +31,7 @@ defmodule NimbleTemplate.Template do
   def install_addon_prompt?(addon),
     do: Mix.shell().yes?("\nWould you like to add the #{addon} addon?")
 
-  # Common setup for both API and Web projects
-  defp common_setup(%Project{} = project) do
-    project
-    |> Addons.ElixirVersion.apply()
-    |> Addons.Readme.apply()
-    |> Addons.Makefile.apply()
-    |> Addons.Docker.apply()
-    |> Addons.MixRelease.apply()
-    |> Addons.TestEnv.apply()
-    |> Addons.Credo.apply()
-    |> Addons.Dialyxir.apply()
-    |> Addons.ExCoveralls.apply()
-    |> Addons.ExMachina.apply()
-    |> Addons.Mimic.apply()
-
-    if host_on_github?() do
-      if generate_github_template?(),
-        do: Addons.Github.apply(project, %{github_template: true})
-
-      if generate_github_action?(),
-        do: Addons.Github.apply(project, %{github_action: true})
-    end
-
-    if install_addon_prompt?("Oban"), do: Addons.Oban.apply(project)
-    if install_addon_prompt?("ExVCR"), do: Addons.ExVCR.apply(project)
-
-    project
+  defp fetch_and_install_dependencies() do
+    if Mix.shell().yes?("\nFetch and install dependencies?"), do: Mix.shell().cmd("mix deps.get")
   end
-
-  defp variant_setup(%Project{api_project?: true} = project), do: ApiTemplate.apply(project)
-
-  defp variant_setup(%Project{web_project?: true, live_project?: false} = project),
-    do: WebTemplate.apply(project)
-
-  defp variant_setup(%Project{web_project?: true, live_project?: true} = project),
-    do: LiveTemplate.apply(project)
 end

--- a/lib/nimble_template/template.ex
+++ b/lib/nimble_template/template.ex
@@ -31,7 +31,7 @@ defmodule NimbleTemplate.Template do
   def install_addon_prompt?(addon),
     do: Mix.shell().yes?("\nWould you like to add the #{addon} addon?")
 
-  defp fetch_and_install_dependencies() do
-    if Mix.shell().yes?("\nFetch and install dependencies?"), do: Mix.shell().cmd("mix deps.get")
-  end
+  defp fetch_and_install_dependencies(),
+    do:
+      if(Mix.shell().yes?("\nFetch and install dependencies?"), do: Mix.shell().cmd("mix deps.get"))
 end

--- a/lib/nimble_template/template.ex
+++ b/lib/nimble_template/template.ex
@@ -3,7 +3,7 @@ defmodule NimbleTemplate.Template do
 
   alias NimbleTemplate.Mix.Template, as: MixTemplate
   alias NimbleTemplate.Phoenix.Template, as: PhoenixTemplate
-  alias NimbleTemplate.{Addons, Project}
+  alias NimbleTemplate.Project
 
   def apply(%Project{mix_project?: true} = project) do
     MixTemplate.apply(project)

--- a/lib/nimble_template/variants/phoenix/api/template.ex
+++ b/lib/nimble_template/variants/phoenix/api/template.ex
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Api.Template do
+defmodule NimbleTemplate.Phoenix.Api.Template do
   @moduledoc false
 
   alias NimbleTemplate.Project

--- a/lib/nimble_template/variants/phoenix/live/template.ex
+++ b/lib/nimble_template/variants/phoenix/live/template.ex
@@ -1,8 +1,8 @@
-defmodule NimbleTemplate.Live.Template do
+defmodule NimbleTemplate.Phoenix.Live.Template do
   @moduledoc false
 
   alias NimbleTemplate.Project
-  alias NimbleTemplate.Web.Template, as: WebTemplate
+  alias NimbleTemplate.Phoenix.Web.Template, as: WebTemplate
 
   def apply(%Project{} = project) do
     WebTemplate.apply(project)

--- a/lib/nimble_template/variants/phoenix/live/template.ex
+++ b/lib/nimble_template/variants/phoenix/live/template.ex
@@ -1,8 +1,8 @@
 defmodule NimbleTemplate.Phoenix.Live.Template do
   @moduledoc false
 
-  alias NimbleTemplate.Project
   alias NimbleTemplate.Phoenix.Web.Template, as: WebTemplate
+  alias NimbleTemplate.Project
 
   def apply(%Project{} = project) do
     WebTemplate.apply(project)

--- a/lib/nimble_template/variants/phoenix/template.ex
+++ b/lib/nimble_template/variants/phoenix/template.ex
@@ -9,9 +9,9 @@ defmodule NimbleTemplate.Phoenix.Template do
       install_addon_prompt?: 1
     ]
 
-  alias NimbleTemplate.Api.Template, as: ApiTemplate
-  alias NimbleTemplate.Live.Template, as: LiveTemplate
-  alias NimbleTemplate.Web.Template, as: WebTemplate
+  alias NimbleTemplate.Phoenix.Api.Template, as: ApiTemplate
+  alias NimbleTemplate.Phoenix.Live.Template, as: LiveTemplate
+  alias NimbleTemplate.Phoenix.Web.Template, as: WebTemplate
   alias NimbleTemplate.{Addons, Project}
 
   def apply(%Project{} = project) do

--- a/lib/nimble_template/variants/phoenix/template.ex
+++ b/lib/nimble_template/variants/phoenix/template.ex
@@ -1,0 +1,58 @@
+defmodule NimbleTemplate.Phoenix.Template do
+  @moduledoc false
+
+  import NimbleTemplate.Template,
+    only: [
+      host_on_github?: 0,
+      generate_github_template?: 0,
+      generate_github_action?: 0,
+      install_addon_prompt?: 1
+    ]
+
+  alias NimbleTemplate.Api.Template, as: ApiTemplate
+  alias NimbleTemplate.Live.Template, as: LiveTemplate
+  alias NimbleTemplate.Web.Template, as: WebTemplate
+  alias NimbleTemplate.{Addons, Project}
+
+  def apply(%Project{} = project) do
+    project
+    |> common_setup()
+    |> variant_setup()
+  end
+
+  defp common_setup(%Project{} = project) do
+    project
+    |> Addons.ElixirVersion.apply()
+    |> Addons.Readme.apply()
+    |> Addons.Makefile.apply()
+    |> Addons.Docker.apply()
+    |> Addons.MixRelease.apply()
+    |> Addons.TestEnv.apply()
+    |> Addons.Credo.apply()
+    |> Addons.Dialyxir.apply()
+    |> Addons.ExCoveralls.apply()
+    |> Addons.ExMachina.apply()
+    |> Addons.Mimic.apply()
+
+    if host_on_github?() do
+      if generate_github_template?(),
+        do: Addons.Github.apply(project, %{github_template: true})
+
+      if generate_github_action?(),
+        do: Addons.Github.apply(project, %{github_action: true})
+    end
+
+    if install_addon_prompt?("Oban"), do: Addons.Oban.apply(project)
+    if install_addon_prompt?("ExVCR"), do: Addons.ExVCR.apply(project)
+
+    project
+  end
+
+  defp variant_setup(%Project{api_project?: true} = project), do: ApiTemplate.apply(project)
+
+  defp variant_setup(%Project{web_project?: true, live_project?: false} = project),
+    do: WebTemplate.apply(project)
+
+  defp variant_setup(%Project{web_project?: true, live_project?: true} = project),
+    do: LiveTemplate.apply(project)
+end

--- a/lib/nimble_template/variants/phoenix/web/template.ex
+++ b/lib/nimble_template/variants/phoenix/web/template.ex
@@ -1,7 +1,7 @@
-defmodule NimbleTemplate.Web.Template do
+defmodule NimbleTemplate.Phoenix.Web.Template do
   @moduledoc false
 
-  alias NimbleTemplate.Addons.Web
+  alias NimbleTemplate.Addons.Phoenix.Web
   alias NimbleTemplate.Project
 
   def apply(%Project{} = project) do

--- a/test/nimble_template/addons/credo_test.exs
+++ b/test/nimble_template/addons/credo_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.Addons.CredoTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
     @describetag mock_latest_package_versions: [{:credo, "1.4"}]

--- a/test/nimble_template/addons/dialyxir_test.exs
+++ b/test/nimble_template/addons/dialyxir_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.Addons.DialyxirTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
     @describetag mock_latest_package_versions: [{:dialyxir, "1.0"}]

--- a/test/nimble_template/addons/docker_test.exs
+++ b/test/nimble_template/addons/docker_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.Addons.DockerTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
     test "copies the docker-compose.dev.yml", %{

--- a/test/nimble_template/addons/elixir_version_test.exs
+++ b/test/nimble_template/addons/elixir_version_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.Addons.ElixirVersionTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
     test "copies the .tool-versions", %{

--- a/test/nimble_template/addons/ex_coveralls_test.exs
+++ b/test/nimble_template/addons/ex_coveralls_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.Addons.ExCoverallsTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
     @describetag mock_latest_package_versions: [{:excoveralls, "0.12.2"}]

--- a/test/nimble_template/addons/ex_machina_test.exs
+++ b/test/nimble_template/addons/ex_machina_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.Addons.ExMachinaTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
     @describetag mock_latest_package_versions: [{:ex_machina, "2.4"}]

--- a/test/nimble_template/addons/github_test.exs
+++ b/test/nimble_template/addons/github_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.Addons.GithubTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2 with github_template option" do
     test "copies the .github/ISSUE_TEMPLATE.md", %{

--- a/test/nimble_template/addons/makefile_test.exs
+++ b/test/nimble_template/addons/makefile_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.Addons.MakefileTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
     test "copies the Makefile", %{project: project, test_project_path: test_project_path} do

--- a/test/nimble_template/addons/mimic_test.exs
+++ b/test/nimble_template/addons/mimic_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.Addons.MimicTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
     @describetag mock_latest_package_versions: [{:mimic, "1.3.1"}]

--- a/test/nimble_template/addons/mix_release_test.exs
+++ b/test/nimble_template/addons/mix_release_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.Addons.MixReleaseTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
     test "deletes the import_config \"prod.secret.exs\" in config/prod.exs", %{

--- a/test/nimble_template/addons/oban_test.exs
+++ b/test/nimble_template/addons/oban_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.Addons.ObanTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
   use Mimic
 
   describe "#apply/2" do

--- a/test/nimble_template/addons/readme_test.exs
+++ b/test/nimble_template/addons/readme_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.Addons.ReadmeTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
     test "copies the README.md", %{

--- a/test/nimble_template/addons/test_env_test.exs
+++ b/test/nimble_template/addons/test_env_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.Addons.TestEnvTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
     test "injects the DB_HOST ENV", %{project: project, test_project_path: test_project_path} do

--- a/test/nimble_template/addons/variants/phoenix/web/assets_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/assets_test.exs
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.AddonsWeb.AssetsTest do
+defmodule NimbleTemplate.Addons.Phoenix.Web.AssetsTest do
   use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do

--- a/test/nimble_template/addons/variants/phoenix/web/core_js_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/core_js_test.exs
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.AddonsWeb.CoreJSTest do
+defmodule NimbleTemplate.Addons.Phoenix.Web.CoreJSTest do
   use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do

--- a/test/nimble_template/addons/variants/phoenix/web/sobelow_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/sobelow_test.exs
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.AddonsWeb.SobelowTest do
+defmodule NimbleTemplate.Addons.Phoenix.Web.SobelowTest do
   use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do

--- a/test/nimble_template/addons/variants/phoenix/web/wallaby_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/wallaby_test.exs
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.AddonsWeb.WallabyTest do
+defmodule NimbleTemplate.Addons.Phoenix.Web.WallabyTest do
   use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do

--- a/test/nimble_template/addons/variants/web/assets_test.exs
+++ b/test/nimble_template/addons/variants/web/assets_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.AddonsWeb.AssetsTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
     test "adds assets.compile alias", %{project: project, test_project_path: test_project_path} do

--- a/test/nimble_template/addons/variants/web/core_js_test.exs
+++ b/test/nimble_template/addons/variants/web/core_js_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.AddonsWeb.CoreJSTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
     test "adds core-js into package.json", %{

--- a/test/nimble_template/addons/variants/web/sobelow_test.exs
+++ b/test/nimble_template/addons/variants/web/sobelow_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.AddonsWeb.SobelowTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
     @describetag mock_latest_package_versions: [{:credo, "0.26.2"}, {:sobelow, "0.8"}]

--- a/test/nimble_template/addons/variants/web/wallaby_test.exs
+++ b/test/nimble_template/addons/variants/web/wallaby_test.exs
@@ -1,5 +1,5 @@
 defmodule NimbleTemplate.AddonsWeb.WallabyTest do
-  use NimbleTemplate.AddonCase
+  use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
     @describetag mock_latest_package_versions: [{:wallaby, "0.26.2"}]

--- a/test/support/addon_case.ex
+++ b/test/support/addon_case.ex
@@ -3,14 +3,14 @@ defmodule NimbleTemplate.AddonCase do
 
   use Mimic
 
-  alias NimbleTemplate.Addons.Web, as: AddonsWeb
+  alias NimbleTemplate.Addons.Phoenix.Web, as: AddonsWeb
   alias NimbleTemplate.{Addons, Project}
   alias NimbleTemplate.Hex.Package
 
   using do
     quote do
       alias NimbleTemplate.Addons
-      alias NimbleTemplate.Addons.Web, as: AddonsWeb
+      alias NimbleTemplate.Addons.Phoenix.Web, as: AddonsWeb
 
       # ATTENTION: File.cd! doesn't support `async: true`, the test will fail randomly in async mode
       # https://elixirforum.com/t/randomly-getting-compilationerror-on-tests/17298/3


### PR DESCRIPTION
## What happened

Describe the big picture of your changes here to communicate to the team why we should accept this pull request. 
 
## Insight

We are having the Mix variant now so better to moving the Web, Live, and API variant into the Phoenix folder.

Also adding `async: false` to each addon test to clarify these tests can't run as async. ([ref](https://github.com/nimblehq/elixir-templates/blob/develop/test/support/addon_case.ex#L15))
 
## Proof Of Work

1/ The test is passed

2/ Variant template folder structure

![image](https://user-images.githubusercontent.com/11751745/113970199-ab1cb600-9860-11eb-9950-f0d183d99c9e.png)

3/ Variant addon folder structure

![image](https://user-images.githubusercontent.com/11751745/113970226-bbcd2c00-9860-11eb-8f39-24f82a5baf6e.png)

4/ Test folder structure

![image](https://user-images.githubusercontent.com/11751745/113970260-ca1b4800-9860-11eb-8e65-8bef7675efb4.png)

5/ 

![image](https://user-images.githubusercontent.com/11751745/113970603-5fb6d780-9861-11eb-9a0b-ecffc19f8005.png)