### PR TITLE
Add .keep file when creating worker directory

### DIFF
--- a/lib/nimble_template/addons/oban.ex
+++ b/lib/nimble_template/addons/oban.ex
@@ -36,7 +36,7 @@ defmodule NimbleTemplate.Addons.Oban do
   end
 
   defp create_folders(%Project{otp_app: otp_app} = project) do
-    File.mkdir("lib/" <> Atom.to_string(otp_app) <> "_worker")
+    Generator.make_directory("lib/" <> Atom.to_string(otp_app) <> "_worker")
 
     project
   end

--- a/test/nimble_template/addons/oban_test.exs
+++ b/test/nimble_template/addons/oban_test.exs
@@ -106,14 +106,14 @@ defmodule NimbleTemplate.Addons.ObanTest do
       end)
     end
 
-    test "creates the worker folder", %{
+    test "creates the worker folder with .keep file", %{
       project: project,
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
         Addons.Oban.apply(project)
 
-        assert(File.dir?("lib/nimble_template_worker")) == true
+        assert(File.exists?("lib/nimble_template_worker/.keep")) == true
       end)
     end
   end


### PR DESCRIPTION
## What happened

Create .keep file when creating a blank directory so when commit generated project all the directory structure is committed.
 
## Proof Of Work

.keep file is created when generating project with Oban

![image](https://user-images.githubusercontent.com/14077479/115009270-53bcbc80-9ed6-11eb-8843-8ff0750d8de1.png)
