### PR TITLE
Enable the test release version workflow

### DIFF
--- a/.github/workflows/test_release_version.yml
+++ b/.github/workflows/test_release_version.yml
@@ -1,53 +1,53 @@
-# name: "Test Release version"
+name: "Test Release version"
 
-# on:
-#   push:
-#     branches:
-#       - 'release/**'
+on:
+  push:
+    branches:
+      - 'release/**'
 
-# env:
-#   OTP_VERSION: 23.3
-#   ELIXIR_VERSION: 1.11.4
-#   PHOENIX_VERSION: 1.5.7
-#   MIX_ENV: test
+env:
+  OTP_VERSION: 23.3
+  ELIXIR_VERSION: 1.11.4
+  PHOENIX_VERSION: 1.5.7
+  MIX_ENV: test
 
-# jobs:
-#   release_version_test:
-#     runs-on: ubuntu-latest
+jobs:
+  release_version_test:
+    runs-on: ubuntu-latest
 
-#     steps:
-#       - name: Cancel Previous Runs
-#         uses: styfle/cancel-workflow-action@0.8.0
-#         with:
-#           access_token: ${{ github.token }}
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
 
-#       - uses: actions/checkout@v2
-#         with:
-#           ref: ${{ github.head_ref }}
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
 
-#      - uses: erlef/setup-elixir@v1
-#        with:
-#          otp-version: ${{ env.OTP_VERSION }}
-#          elixir-version: ${{ env.ELIXIR_VERSION }}
+     - uses: erlef/setup-elixir@v1
+       with:
+         otp-version: ${{ env.OTP_VERSION }}
+         elixir-version: ${{ env.ELIXIR_VERSION }}
 
-#       - name: Cache Elixir build
-#         uses: actions/cache@v2
-#         with:
-#           path: |
-#             _build
-#             deps
-#           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-#           restore-keys: |
-#             ${{ runner.os }}-mix-
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
 
-#       - name: Install Dependencies
-#         run: mix deps.get
+      - name: Install Dependencies
+        run: mix deps.get
         
-#       - name: Compile dependencies
-#         run: mix compile --warnings-as-errors --all-warnings
+      - name: Compile dependencies
+        run: mix compile --warnings-as-errors --all-warnings
         
-#       - name: Install Phoenix ${{ env.PHOENIX_VERSION }}
-#         run: make install_phoenix PHOENIX_VERSION=${{ env.PHOENIX_VERSION }}
+      - name: Install Phoenix ${{ env.PHOENIX_VERSION }}
+        run: make install_phoenix PHOENIX_VERSION=${{ env.PHOENIX_VERSION }}
           
-#       - name: Run Tests
-#         run: mix test --only release_version
+      - name: Run Tests
+        run: mix test --only release_version

--- a/.github/workflows/test_release_version.yml
+++ b/.github/workflows/test_release_version.yml
@@ -1,4 +1,4 @@
-name: "Test Release version"
+name: Test Release version
 
 on:
   push:
@@ -21,11 +21,13 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
 
-     - uses: erlef/setup-elixir@v1
+     - name: Setup Elixir
+       uses: erlef/setup-elixir@v1
        with:
          otp-version: ${{ env.OTP_VERSION }}
          elixir-version: ${{ env.ELIXIR_VERSION }}


### PR DESCRIPTION
## What happened

Enable the test Release version workflow
 
## Insight

Because we changed the package name to `nimble_template` on the previous version, at that time the `nimble_template` didn't exist on Hex yet so we need to disable this workflow on that release.
 
## Proof Of Work
