### PR TITLE
Use - instead of * in the markdown bullet list

### DIFF
--- a/priv/templates/nimble_template/README.md.eex
+++ b/priv/templates/nimble_template/README.md.eex
@@ -8,11 +8,11 @@
 
 ### Erlang & Elixir
 
-* Erlang <%= erlang_version %>
+- Erlang <%= erlang_version %>
 
-* Elixir <%= elixir_version %>
+- Elixir <%= elixir_version %>
 
-* Recommended version manager.
+- Recommended version manager.
 
   - [asdf](https://github.com/asdf-vm/asdf)
   - [asdf-erlang](https://github.com/asdf-vm/asdf-erlang)
@@ -20,51 +20,51 @@
 
 ### Development
 
-* Install [Docker for Mac](https://docs.docker.com/docker-for-mac/install/)
+- Install [Docker for Mac](https://docs.docker.com/docker-for-mac/install/)
 
-* Setup and boot the Docker containers:
+- Setup and boot the Docker containers:
 
   ```sh
   make docker_setup
   ```
 
-* Install Elixir dependencies:
+- Install Elixir dependencies:
 
   ```sh
   mix deps.get
   ```
 <%= if web_project? do %>
-* Install Node dependencies:
+- Install Node dependencies:
 
   ```sh
   npm install --prefix assets
   ```
 <% end %>
-* Setup the databases:
+- Setup the databases:
 
   ```sh
   mix ecto.setup
   ```
 
-* Start the Phoenix app
+- Start the Phoenix app
 
   ```sh
   iex -S mix phx.server
   ```
 
-* Run all tests:
+- Run all tests:
 
   ```sh
   mix test 
   ```
 
-* Run all lint:
+- Run all lint:
 
   ```sh
   mix codebase 
   ```
   
-* Test coverage:
+- Test coverage:
 
   ```sh
   mix coverage 
@@ -72,7 +72,7 @@
 
 ### Production
 
-* Build Docker image
+- Build Docker image
 
   ```sh
   docker-compose build

--- a/priv/templates/nimble_template/README.md.mix.eex
+++ b/priv/templates/nimble_template/README.md.mix.eex
@@ -8,11 +8,11 @@
 
 ### Erlang & Elixir
 
-* Erlang <%= erlang_version %>
+- Erlang <%= erlang_version %>
 
-* Elixir <%= elixir_version %>
+- Elixir <%= elixir_version %>
 
-* Recommended version manager.
+- Recommended version manager.
 
   - [asdf](https://github.com/asdf-vm/asdf)
   - [asdf-erlang](https://github.com/asdf-vm/asdf-erlang)
@@ -20,25 +20,25 @@
 
 ### Development
 
-* Install Elixir dependencies:
+- Install Elixir dependencies:
 
   ```sh
   mix deps.get
   ```
 
-* Run all tests:
+- Run all tests:
 
   ```sh
   mix test 
   ```
 
-* Run all lint:
+- Run all lint:
 
   ```sh
   mix codebase 
   ```
 
-* Test coverage:
+- Test coverage:
 
   ```sh
   mix coverage 

--- a/test/nimble_template/addons/readme_test.exs
+++ b/test/nimble_template/addons/readme_test.exs
@@ -14,7 +14,7 @@ defmodule NimbleTemplate.Addons.ReadmeTest do
           assert file =~ "Elixir 1.11.4"
 
           assert file =~ """
-                 * Install Node dependencies:
+                 - Install Node dependencies:
 
                    ```sh
                    npm install --prefix assets
@@ -22,7 +22,7 @@ defmodule NimbleTemplate.Addons.ReadmeTest do
                  """
 
           assert file =~ """
-                 * Start the Phoenix app
+                 - Start the Phoenix app
 
                    ```sh
                    iex -S mix phx.server
@@ -48,7 +48,7 @@ defmodule NimbleTemplate.Addons.ReadmeTest do
           assert file =~ "Elixir 1.11.4"
 
           refute file =~ """
-                 * Install Node dependencies:
+                 - Install Node dependencies:
 
                    ```sh
                    npm install --prefix assets
@@ -56,7 +56,7 @@ defmodule NimbleTemplate.Addons.ReadmeTest do
                  """
 
           assert file =~ """
-                 * Start the Phoenix app
+                 - Start the Phoenix app
 
                    ```sh
                    iex -S mix phx.server
@@ -82,7 +82,7 @@ defmodule NimbleTemplate.Addons.ReadmeTest do
           assert file =~ "Elixir 1.11.4"
 
           refute file =~ """
-                 * Install Node dependencies:
+                 - Install Node dependencies:
 
                    ```sh
                    npm install --prefix assets
@@ -90,7 +90,7 @@ defmodule NimbleTemplate.Addons.ReadmeTest do
                  """
 
           refute file =~ """
-                 * Start the Phoenix app
+                 - Start the Phoenix app
 
                    ```sh
                    iex -S mix phx.server


### PR DESCRIPTION
## What happened

We defined [markdown convention](https://nimblehq.co/compass/intro/contribute/#markdown) in the compass to use `-` instead of `*` for bullet list. So I updated markdown template file to use `-` instead of `*`
 
## Insight

Updated following files ...
- `priv/templates/nimble_template/README.md.eex`
- `priv/templates/nimble_template/README.md.mix.eex`
- `test/nimble_template/addons/readme_test.exs`
 
## Proof Of Work

Spec should be passed
