### PR TITLE
Upgrade Elixir version to 1.12.1

### DIFF
--- a/.github/workflows/publish_to_hex_pm.yml
+++ b/.github/workflows/publish_to_hex_pm.yml
@@ -11,8 +11,8 @@ on:
   workflow_dispatch:
 
 env:
-  OTP_VERSION: 24.0.1
-  ELIXIR_VERSION: 1.12.1
+  OTP_VERSION: 24.0.4
+  ELIXIR_VERSION: 1.12.2
 
 jobs:
   publish:

--- a/.github/workflows/publish_to_hex_pm.yml
+++ b/.github/workflows/publish_to_hex_pm.yml
@@ -11,10 +11,10 @@ on:
   workflow_dispatch:
 
 env:
-  OTP_VERSION: 23.3
-  ELIXIR_VERSION: 1.11.4
+  OTP_VERSION: 24.0.1
+  ELIXIR_VERSION: 1.12.1
 
-jobs:   
+jobs:
   publish:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
@@ -23,7 +23,7 @@ jobs:
         uses: styfle/cancel-workflow-action@0.8.0
         with:
           access_token: ${{ github.token }}
-      
+
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}

--- a/.github/workflows/test_api_variant_on_custom_api_project.yml
+++ b/.github/workflows/test_api_variant_on_custom_api_project.yml
@@ -3,8 +3,8 @@ name: "Test API variant on custom API project"
 on: push
 
 env:
-  OTP_VERSION: 24.0.1
-  ELIXIR_VERSION: 1.12.1
+  OTP_VERSION: 24.0.4
+  ELIXIR_VERSION: 1.12.2
   PHOENIX_VERSION: 1.5.7
 
 jobs:

--- a/.github/workflows/test_api_variant_on_custom_api_project.yml
+++ b/.github/workflows/test_api_variant_on_custom_api_project.yml
@@ -3,14 +3,14 @@ name: "Test API variant on custom API project"
 on: push
 
 env:
-  OTP_VERSION: 23.3
-  ELIXIR_VERSION: 1.11.4
+  OTP_VERSION: 24.0.1
+  ELIXIR_VERSION: 1.12.1
   PHOENIX_VERSION: 1.5.7
 
-jobs:   
+jobs:
   unit_test:
     runs-on: ubuntu-latest
-    
+
     services:
       db:
         image: postgres:12.3
@@ -22,13 +22,13 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-        
+
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.8.0
         with:
           access_token: ${{ github.token }}
-      
+
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
@@ -37,7 +37,7 @@ jobs:
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
-          
+
       - name: Cache Elixir build
         uses: actions/cache@v2
         with:
@@ -47,7 +47,7 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
-              
+
       - uses: nimblehq/elixir-templates@composite_1.4
         with:
           new_project_options: '--no-html --no-webpack --module=CustomModule --app=custom_app'

--- a/.github/workflows/test_api_variant_on_standard_api_project.yml
+++ b/.github/workflows/test_api_variant_on_standard_api_project.yml
@@ -3,8 +3,8 @@ name: "Test API variant on standard API project"
 on: push
 
 env:
-  OTP_VERSION: 24.0.1
-  ELIXIR_VERSION: 1.12.1
+  OTP_VERSION: 24.0.4
+  ELIXIR_VERSION: 1.12.2
   PHOENIX_VERSION: 1.5.7
 
 jobs:

--- a/.github/workflows/test_api_variant_on_standard_api_project.yml
+++ b/.github/workflows/test_api_variant_on_standard_api_project.yml
@@ -3,14 +3,14 @@ name: "Test API variant on standard API project"
 on: push
 
 env:
-  OTP_VERSION: 23.3
-  ELIXIR_VERSION: 1.11.4
+  OTP_VERSION: 24.0.1
+  ELIXIR_VERSION: 1.12.1
   PHOENIX_VERSION: 1.5.7
 
-jobs:   
+jobs:
   unit_test:
     runs-on: ubuntu-latest
-    
+
     services:
       db:
         image: postgres:12.3
@@ -22,7 +22,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-        
+
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.8.0
@@ -37,7 +37,7 @@ jobs:
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
-          
+
       - name: Cache Elixir build
         uses: actions/cache@v2
         with:
@@ -47,7 +47,7 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
-              
+
       - uses: nimblehq/elixir-templates@composite_1.4
         with:
           new_project_options: '--no-html --no-webpack'

--- a/.github/workflows/test_live_variant_on_custom_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_custom_liveview_project.yml
@@ -3,15 +3,15 @@ name: "Test Live variant on custom LiveView project"
 on: push
 
 env:
-  OTP_VERSION: 23.3
-  ELIXIR_VERSION: 1.11.4
+  OTP_VERSION: 24.0.1
+  ELIXIR_VERSION: 1.12.1
   PHOENIX_VERSION: 1.5.7
   NODE_VERSION: 14
 
-jobs:   
+jobs:
   unit_test:
     runs-on: ubuntu-latest
-    
+
     services:
       db:
         image: postgres:12.3
@@ -23,7 +23,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-        
+
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.8.0
@@ -38,11 +38,11 @@ jobs:
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
-        
+
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ env.NODE_VERSION }}
-          
+
       - name: Cache Elixir build
         uses: actions/cache@v2
         with:
@@ -52,7 +52,7 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
-      
+
       - name: Cache Node npm
         uses: actions/cache@v2
         with:
@@ -61,7 +61,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-              
+
       - uses: nimblehq/elixir-templates@composite_1.4
         with:
           new_project_options: '--live --module=CustomModule --app=custom_app'

--- a/.github/workflows/test_live_variant_on_custom_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_custom_liveview_project.yml
@@ -3,8 +3,8 @@ name: "Test Live variant on custom LiveView project"
 on: push
 
 env:
-  OTP_VERSION: 24.0.1
-  ELIXIR_VERSION: 1.12.1
+  OTP_VERSION: 24.0.4
+  ELIXIR_VERSION: 1.12.2
   PHOENIX_VERSION: 1.5.7
   NODE_VERSION: 14
 

--- a/.github/workflows/test_live_variant_on_standard_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_standard_liveview_project.yml
@@ -3,15 +3,15 @@ name: "Test Live variant on standard LiveView project"
 on: push
 
 env:
-  OTP_VERSION: 23.3
-  ELIXIR_VERSION: 1.11.4
+  OTP_VERSION: 24.0.1
+  ELIXIR_VERSION: 1.12.1
   PHOENIX_VERSION: 1.5.7
   NODE_VERSION: 14
 
-jobs:   
+jobs:
   unit_test:
     runs-on: ubuntu-latest
-    
+
     services:
       db:
         image: postgres:12.3
@@ -23,7 +23,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-        
+
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.8.0
@@ -38,11 +38,11 @@ jobs:
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
-          
+
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ env.NODE_VERSION }}
-          
+
       - name: Cache Elixir build
         uses: actions/cache@v2
         with:
@@ -52,7 +52,7 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
-      
+
       - name: Cache Node npm
         uses: actions/cache@v2
         with:
@@ -61,7 +61,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-              
+
       - uses: nimblehq/elixir-templates@composite_1.4
         with:
           new_project_options: '--live'

--- a/.github/workflows/test_live_variant_on_standard_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_standard_liveview_project.yml
@@ -3,8 +3,8 @@ name: "Test Live variant on standard LiveView project"
 on: push
 
 env:
-  OTP_VERSION: 24.0.1
-  ELIXIR_VERSION: 1.12.1
+  OTP_VERSION: 24.0.4
+  ELIXIR_VERSION: 1.12.2
   PHOENIX_VERSION: 1.5.7
   NODE_VERSION: 14
 

--- a/.github/workflows/test_mix_variant_on_custom_mix_project.yml
+++ b/.github/workflows/test_mix_variant_on_custom_mix_project.yml
@@ -3,8 +3,8 @@ name: "Test Mix variant on custom Mix project"
 on: push
 
 env:
-  OTP_VERSION: 24.0.1
-  ELIXIR_VERSION: 1.12.1
+  OTP_VERSION: 24.0.4
+  ELIXIR_VERSION: 1.12.2
   MIX_ENV: test
 
 jobs:

--- a/.github/workflows/test_mix_variant_on_custom_mix_project.yml
+++ b/.github/workflows/test_mix_variant_on_custom_mix_project.yml
@@ -3,11 +3,11 @@ name: "Test Mix variant on custom Mix project"
 on: push
 
 env:
-  OTP_VERSION: 23.3
-  ELIXIR_VERSION: 1.11.4
+  OTP_VERSION: 24.0.1
+  ELIXIR_VERSION: 1.12.1
   MIX_ENV: test
 
-jobs:   
+jobs:
   unit_test:
     runs-on: ubuntu-latest
 
@@ -25,7 +25,7 @@ jobs:
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
-          
+
       - name: Cache Elixir build
         uses: actions/cache@v2
         with:
@@ -35,7 +35,7 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
-      
+
       - name: Create Mix project
         run: make create_mix_project PROJECT_DIRECTORY=sample_project OPTIONS="--module=CustomModule --app=custom_app"
 
@@ -44,12 +44,12 @@ jobs:
 
       - name: Install Elixir Dependencies
         run: cd sample_project && mix deps.get
-      
+
       - name: Compile dependencies
         run: cd sample_project && mix compile --warnings-as-errors --all-warnings
-      
+
       - name: Run mix codebase
         run: cd sample_project && mix codebase
-        
+
       - name: Run mix test
         run: cd sample_project && mix test

--- a/.github/workflows/test_mix_variant_on_custom_mix_project_with_supervision.yml
+++ b/.github/workflows/test_mix_variant_on_custom_mix_project_with_supervision.yml
@@ -3,8 +3,8 @@ name: "Test Mix variant on custom Mix project with --sup option"
 on: push
 
 env:
-  OTP_VERSION: 24.0.1
-  ELIXIR_VERSION: 1.12.1
+  OTP_VERSION: 24.0.4
+  ELIXIR_VERSION: 1.12.2
   MIX_ENV: test
 
 jobs:

--- a/.github/workflows/test_mix_variant_on_custom_mix_project_with_supervision.yml
+++ b/.github/workflows/test_mix_variant_on_custom_mix_project_with_supervision.yml
@@ -3,11 +3,11 @@ name: "Test Mix variant on custom Mix project with --sup option"
 on: push
 
 env:
-  OTP_VERSION: 23.3
-  ELIXIR_VERSION: 1.11.4
+  OTP_VERSION: 24.0.1
+  ELIXIR_VERSION: 1.12.1
   MIX_ENV: test
 
-jobs:   
+jobs:
   unit_test:
     runs-on: ubuntu-latest
 
@@ -25,7 +25,7 @@ jobs:
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
-          
+
       - name: Cache Elixir build
         uses: actions/cache@v2
         with:
@@ -35,7 +35,7 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
-      
+
       - name: Create Mix project
         run: make create_mix_project PROJECT_DIRECTORY=sample_project OPTIONS="--module=CustomModule --app=custom_app --sup"
 
@@ -44,12 +44,12 @@ jobs:
 
       - name: Install Elixir Dependencies
         run: cd sample_project && mix deps.get
-      
+
       - name: Compile dependencies
         run: cd sample_project && mix compile --warnings-as-errors --all-warnings
-      
+
       - name: Run mix codebase
         run: cd sample_project && mix codebase
-        
+
       - name: Run mix test
         run: cd sample_project && mix test

--- a/.github/workflows/test_mix_variant_on_standard_mix_project.yml
+++ b/.github/workflows/test_mix_variant_on_standard_mix_project.yml
@@ -3,8 +3,8 @@ name: "Test Mix variant on standard Mix project"
 on: push
 
 env:
-  OTP_VERSION: 24.0.1
-  ELIXIR_VERSION: 1.12.1
+  OTP_VERSION: 24.0.4
+  ELIXIR_VERSION: 1.12.2
   MIX_ENV: test
 
 jobs:

--- a/.github/workflows/test_mix_variant_on_standard_mix_project.yml
+++ b/.github/workflows/test_mix_variant_on_standard_mix_project.yml
@@ -3,11 +3,11 @@ name: "Test Mix variant on standard Mix project"
 on: push
 
 env:
-  OTP_VERSION: 23.3
-  ELIXIR_VERSION: 1.11.4
+  OTP_VERSION: 24.0.1
+  ELIXIR_VERSION: 1.12.1
   MIX_ENV: test
 
-jobs:   
+jobs:
   unit_test:
     runs-on: ubuntu-latest
 
@@ -25,7 +25,7 @@ jobs:
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
-          
+
       - name: Cache Elixir build
         uses: actions/cache@v2
         with:
@@ -35,7 +35,7 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
-      
+
       - name: Create Mix project
         run: make create_mix_project PROJECT_DIRECTORY=sample_project OPTIONS=""
 
@@ -44,12 +44,12 @@ jobs:
 
       - name: Install Elixir Dependencies
         run: cd sample_project && mix deps.get
-      
+
       - name: Compile dependencies
         run: cd sample_project && mix compile --warnings-as-errors --all-warnings
-      
+
       - name: Run mix codebase
         run: cd sample_project && mix codebase
-        
+
       - name: Run mix test
         run: cd sample_project && mix test

--- a/.github/workflows/test_mix_variant_on_standard_mix_project_with_supervision.yml
+++ b/.github/workflows/test_mix_variant_on_standard_mix_project_with_supervision.yml
@@ -3,8 +3,8 @@ name: "Test Mix variant on standard Mix project with --sup option"
 on: push
 
 env:
-  OTP_VERSION: 24.0.1
-  ELIXIR_VERSION: 1.12.1
+  OTP_VERSION: 24.0.4
+  ELIXIR_VERSION: 1.12.2
   MIX_ENV: test
 
 jobs:

--- a/.github/workflows/test_mix_variant_on_standard_mix_project_with_supervision.yml
+++ b/.github/workflows/test_mix_variant_on_standard_mix_project_with_supervision.yml
@@ -3,11 +3,11 @@ name: "Test Mix variant on standard Mix project with --sup option"
 on: push
 
 env:
-  OTP_VERSION: 23.3
-  ELIXIR_VERSION: 1.11.4
+  OTP_VERSION: 24.0.1
+  ELIXIR_VERSION: 1.12.1
   MIX_ENV: test
 
-jobs:   
+jobs:
   unit_test:
     runs-on: ubuntu-latest
 
@@ -25,7 +25,7 @@ jobs:
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
-          
+
       - name: Cache Elixir build
         uses: actions/cache@v2
         with:
@@ -35,7 +35,7 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
-      
+
       - name: Create Mix project
         run: make create_mix_project PROJECT_DIRECTORY=sample_project OPTIONS="--sup"
 
@@ -44,12 +44,12 @@ jobs:
 
       - name: Install Elixir Dependencies
         run: cd sample_project && mix deps.get
-      
+
       - name: Compile dependencies
         run: cd sample_project && mix compile --warnings-as-errors --all-warnings
-      
+
       - name: Run mix codebase
         run: cd sample_project && mix codebase
-        
+
       - name: Run mix test
         run: cd sample_project && mix test

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -3,8 +3,8 @@ name: "Test template"
 on: push
 
 env:
-  OTP_VERSION: 24.0.1
-  ELIXIR_VERSION: 1.12.1
+  OTP_VERSION: 24.0.4
+  ELIXIR_VERSION: 1.12.2
   PHOENIX_VERSION: 1.5.7
   MIX_ENV: test
 

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -3,8 +3,8 @@ name: "Test template"
 on: push
 
 env:
-  OTP_VERSION: 23.3
-  ELIXIR_VERSION: 1.11.4
+  OTP_VERSION: 24.0.1
+  ELIXIR_VERSION: 1.12.1
   PHOENIX_VERSION: 1.5.7
   MIX_ENV: test
 
@@ -45,9 +45,9 @@ jobs:
 
       - name: Install Phoenix ${{ env.PHOENIX_VERSION }}
         run: make install_phoenix PHOENIX_VERSION=${{ env.PHOENIX_VERSION }}
-      
+
       - name: Run codebase check
         run: mix codebase
-          
+
       - name: Run Tests
         run: mix test

--- a/.github/workflows/test_variant_on_custom_web_project.yml
+++ b/.github/workflows/test_variant_on_custom_web_project.yml
@@ -3,19 +3,19 @@ name: "Test variant on custom Web project"
 on: push
 
 env:
-  OTP_VERSION: 23.3
-  ELIXIR_VERSION: 1.11.4
+  OTP_VERSION: 24.0.1
+  ELIXIR_VERSION: 1.12.1
   PHOENIX_VERSION: 1.5.7
   NODE_VERSION: 14
 
-jobs:   
+jobs:
   unit_test:
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         variant: [web, api]
-    
+
     services:
       db:
         image: postgres:12.3
@@ -27,7 +27,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-        
+
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.8.0
@@ -42,11 +42,11 @@ jobs:
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
-    
+
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ env.NODE_VERSION }}
-          
+
       - name: Cache Elixir build
         uses: actions/cache@v2
         with:
@@ -56,7 +56,7 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
-      
+
       - name: Cache Node npm
         uses: actions/cache@v2
         with:
@@ -65,7 +65,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-              
+
       - uses: nimblehq/elixir-templates@composite_1.4
         with:
           new_project_options: '--module=CustomModule --app=custom_app'

--- a/.github/workflows/test_variant_on_custom_web_project.yml
+++ b/.github/workflows/test_variant_on_custom_web_project.yml
@@ -3,8 +3,8 @@ name: "Test variant on custom Web project"
 on: push
 
 env:
-  OTP_VERSION: 24.0.1
-  ELIXIR_VERSION: 1.12.1
+  OTP_VERSION: 24.0.4
+  ELIXIR_VERSION: 1.12.2
   PHOENIX_VERSION: 1.5.7
   NODE_VERSION: 14
 

--- a/.github/workflows/test_variant_on_standard_web_project.yml
+++ b/.github/workflows/test_variant_on_standard_web_project.yml
@@ -3,19 +3,19 @@ name: "Test variant on standard Web project"
 on: push
 
 env:
-  OTP_VERSION: 23.3
-  ELIXIR_VERSION: 1.11.4
+  OTP_VERSION: 24.0.1
+  ELIXIR_VERSION: 1.12.1
   PHOENIX_VERSION: 1.5.7
   NODE_VERSION: 14
 
-jobs:   
+jobs:
   unit_test:
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         variant: [web, api]
-    
+
     services:
       db:
         image: postgres:12.3
@@ -27,7 +27,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-        
+
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.8.0
@@ -42,11 +42,11 @@ jobs:
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
-    
+
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ env.NODE_VERSION }}
-          
+
       - name: Cache Elixir build
         uses: actions/cache@v2
         with:
@@ -56,7 +56,7 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
-      
+
       - name: Cache Node npm
         uses: actions/cache@v2
         with:
@@ -65,7 +65,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-              
+
       - uses: nimblehq/elixir-templates@composite_1.4
         with:
           new_project_options: ''

--- a/.github/workflows/test_variant_on_standard_web_project.yml
+++ b/.github/workflows/test_variant_on_standard_web_project.yml
@@ -3,8 +3,8 @@ name: "Test variant on standard Web project"
 on: push
 
 env:
-  OTP_VERSION: 24.0.1
-  ELIXIR_VERSION: 1.12.1
+  OTP_VERSION: 24.0.4
+  ELIXIR_VERSION: 1.12.2
   PHOENIX_VERSION: 1.5.7
   NODE_VERSION: 14
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 24.0.1
-elixir 1.12.1-otp-24
+erlang 24.0.4
+elixir 1.12.2-otp-24

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 23.3
-elixir 1.11.4-otp-23
+erlang 24.0.1
+elixir 1.12.1-otp-24

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Phoenix/Mix template for projects at [Nimble](https://nimblehq.co/).
 
 NimbleTemplate has been developed and actively tested with the below environment:
 
-- Mix 1.12.1
-- Elixir 1.12.1
-- Erlang/OTP 24.0.1
+- Mix 1.12.2
+- Elixir 1.12.2
+- Erlang/OTP 24.0.4
 - Phoenix 1.5.7
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Phoenix/Mix template for projects at [Nimble](https://nimblehq.co/).
 
 NimbleTemplate has been developed and actively tested with the below environment:
 
-- Mix 1.11.4
-- Elixir 1.11.4
-- Erlang/OTP 23.3
+- Mix 1.12.1
+- Elixir 1.12.1
+- Erlang/OTP 24.0.1
 - Phoenix 1.5.7
 
 ## Installation

--- a/lib/nimble_template/project.ex
+++ b/lib/nimble_template/project.ex
@@ -1,9 +1,9 @@
 defmodule NimbleTemplate.Project do
   @moduledoc false
 
-  @alpine_version "3.13.3"
-  @elixir_version "1.12.1"
-  @erlang_version "24.0.1"
+  @alpine_version "3.14.0"
+  @elixir_version "1.12.2"
+  @erlang_version "24.0.4"
   @node_version "14"
 
   defstruct base_module: nil,

--- a/lib/nimble_template/project.ex
+++ b/lib/nimble_template/project.ex
@@ -1,8 +1,8 @@
 defmodule NimbleTemplate.Project do
   @moduledoc false
 
-  @alpine_version "3.13.2"
-  @elixir_version "1.11.4"
+  @alpine_version "3.13.3"
+  @elixir_version "1.12.1"
   @erlang_version "23.3"
   @node_version "14"
 

--- a/lib/nimble_template/project.ex
+++ b/lib/nimble_template/project.ex
@@ -3,7 +3,7 @@ defmodule NimbleTemplate.Project do
 
   @alpine_version "3.13.3"
   @elixir_version "1.12.1"
-  @erlang_version "23.3"
+  @erlang_version "24.0.1"
   @node_version "14"
 
   defstruct base_module: nil,

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule NimbleTemplate.MixProject do
       app: :nimble_template,
       version: "3.0.0",
       description: "Phoenix/Mix template for projects at [Nimble](https://nimblehq.co/).",
-      elixir: "~> 1.12.1",
+      elixir: "~> 1.12.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule NimbleTemplate.MixProject do
       app: :nimble_template,
       version: "3.0.0",
       description: "Phoenix/Mix template for projects at [Nimble](https://nimblehq.co/).",
-      elixir: "~> 1.11.4",
+      elixir: "~> 1.12.1",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/priv/templates/nimble_template/Dockerfile.eex
+++ b/priv/templates/nimble_template/Dockerfile.eex
@@ -38,13 +38,15 @@ FROM alpine:${RELEASE_IMAGE_VERSION} AS app
 
 RUN apk update && \
     apk add --no-cache \
+    libstdc++ \
+    libgcc \
     bash \
     openssl-dev
 
 WORKDIR /opt/app
 EXPOSE 4000
 
-RUN addgroup -g 1000 appuser && \ 
+RUN addgroup -g 1000 appuser && \
 		adduser -u 1000 -G appuser -g appuser -s /bin/sh -D appuser && \
 		chown 1000:1000 /opt/app
 

--- a/priv/templates/nimble_template/coveralls.json.eex
+++ b/priv/templates/nimble_template/coveralls.json.eex
@@ -6,6 +6,8 @@
     "lib/<%= otp_app %>_web.ex",
     "lib/<%= otp_app %>_mail.ex",
     "lib/<%= otp_app %>_web/endpoint.ex",
+    "lib/<%= otp_app %>_web/telemetry.ex",
+    "lib/<%= otp_app %>_web/channels/user_socket.ex",
     "lib/<%= otp_app %>_web/views/error_helpers.ex",
     "test/support"
   ],

--- a/test/nimble_template/addons/docker_test.exs
+++ b/test/nimble_template/addons/docker_test.exs
@@ -58,9 +58,9 @@ defmodule NimbleTemplate.Addons.DockerTest do
 
         assert_file("Dockerfile", fn file ->
           assert file =~ """
-                 ARG ELIXIR_IMAGE_VERSION=1.12.1
-                 ARG ERLANG_IMAGE_VERSION=24.0.1
-                 ARG RELEASE_IMAGE_VERSION=3.13.3
+                 ARG ELIXIR_IMAGE_VERSION=1.12.2
+                 ARG ERLANG_IMAGE_VERSION=24.0.4
+                 ARG RELEASE_IMAGE_VERSION=3.14.0
 
                  FROM hexpm/elixir:${ELIXIR_IMAGE_VERSION}-erlang-${ERLANG_IMAGE_VERSION}-alpine-${RELEASE_IMAGE_VERSION} AS build
                  """

--- a/test/nimble_template/addons/docker_test.exs
+++ b/test/nimble_template/addons/docker_test.exs
@@ -58,9 +58,9 @@ defmodule NimbleTemplate.Addons.DockerTest do
 
         assert_file("Dockerfile", fn file ->
           assert file =~ """
-                 ARG ELIXIR_IMAGE_VERSION=1.11.4
-                 ARG ERLANG_IMAGE_VERSION=23.3
-                 ARG RELEASE_IMAGE_VERSION=3.13.2
+                 ARG ELIXIR_IMAGE_VERSION=1.12.1
+                 ARG ERLANG_IMAGE_VERSION=24.0.1
+                 ARG RELEASE_IMAGE_VERSION=3.13.3
 
                  FROM hexpm/elixir:${ELIXIR_IMAGE_VERSION}-erlang-${ERLANG_IMAGE_VERSION}-alpine-${RELEASE_IMAGE_VERSION} AS build
                  """

--- a/test/nimble_template/addons/elixir_version_test.exs
+++ b/test/nimble_template/addons/elixir_version_test.exs
@@ -11,8 +11,8 @@ defmodule NimbleTemplate.Addons.ElixirVersionTest do
 
         assert_file(".tool-versions", fn file ->
           assert file =~ """
-                 erlang 23.3
-                 elixir 1.11.4-otp-23
+                 erlang 24.0.1
+                 elixir 1.12.1-otp-24
                  """
         end)
       end)

--- a/test/nimble_template/addons/elixir_version_test.exs
+++ b/test/nimble_template/addons/elixir_version_test.exs
@@ -11,8 +11,8 @@ defmodule NimbleTemplate.Addons.ElixirVersionTest do
 
         assert_file(".tool-versions", fn file ->
           assert file =~ """
-                 erlang 24.0.1
-                 elixir 1.12.1-otp-24
+                 erlang 24.0.4
+                 elixir 1.12.2-otp-24
                  """
         end)
       end)

--- a/test/nimble_template/addons/readme_test.exs
+++ b/test/nimble_template/addons/readme_test.exs
@@ -10,8 +10,8 @@ defmodule NimbleTemplate.Addons.ReadmeTest do
         Addons.Readme.apply(project)
 
         assert_file("README.md", fn file ->
-          assert file =~ "Erlang 24.0.1"
-          assert file =~ "Elixir 1.12.1"
+          assert file =~ "Erlang 24.0.4"
+          assert file =~ "Elixir 1.12.2"
 
           assert file =~ """
                  - Install Node dependencies:
@@ -44,8 +44,8 @@ defmodule NimbleTemplate.Addons.ReadmeTest do
         Addons.Readme.apply(project)
 
         assert_file("README.md", fn file ->
-          assert file =~ "Erlang 24.0.1"
-          assert file =~ "Elixir 1.12.1"
+          assert file =~ "Erlang 24.0.4"
+          assert file =~ "Elixir 1.12.2"
 
           refute file =~ """
                  - Install Node dependencies:
@@ -78,8 +78,8 @@ defmodule NimbleTemplate.Addons.ReadmeTest do
         Addons.Readme.apply(project)
 
         assert_file("README.md", fn file ->
-          assert file =~ "Erlang 24.0.1"
-          assert file =~ "Elixir 1.12.1"
+          assert file =~ "Erlang 24.0.4"
+          assert file =~ "Elixir 1.12.2"
 
           refute file =~ """
                  - Install Node dependencies:

--- a/test/nimble_template/addons/readme_test.exs
+++ b/test/nimble_template/addons/readme_test.exs
@@ -10,8 +10,8 @@ defmodule NimbleTemplate.Addons.ReadmeTest do
         Addons.Readme.apply(project)
 
         assert_file("README.md", fn file ->
-          assert file =~ "Erlang 23.3"
-          assert file =~ "Elixir 1.11.4"
+          assert file =~ "Erlang 24.0.1"
+          assert file =~ "Elixir 1.12.1"
 
           assert file =~ """
                  - Install Node dependencies:
@@ -44,8 +44,8 @@ defmodule NimbleTemplate.Addons.ReadmeTest do
         Addons.Readme.apply(project)
 
         assert_file("README.md", fn file ->
-          assert file =~ "Erlang 23.3"
-          assert file =~ "Elixir 1.11.4"
+          assert file =~ "Erlang 24.0.1"
+          assert file =~ "Elixir 1.12.1"
 
           refute file =~ """
                  - Install Node dependencies:
@@ -78,8 +78,8 @@ defmodule NimbleTemplate.Addons.ReadmeTest do
         Addons.Readme.apply(project)
 
         assert_file("README.md", fn file ->
-          assert file =~ "Erlang 23.3"
-          assert file =~ "Elixir 1.11.4"
+          assert file =~ "Erlang 24.0.1"
+          assert file =~ "Elixir 1.12.1"
 
           refute file =~ """
                  - Install Node dependencies:


### PR DESCRIPTION
## What happened

- Update Elixir to 1.12.2
- Update to Erlang/OTP to 24.0.4
 
## Insight

When building for production with the Dockerfile, the app crashed on Heroku 😱 Upon checking the log, it appeared that two C libraries were missing so I updated the Dockerfile. 

![image](https://user-images.githubusercontent.com/696529/122345287-e5e24f00-cf71-11eb-9ce2-562ab7e86bcf.png)

I tested this update on https://github.com/nimblehq/centauri-web/pull/115.

 
## Proof Of Work

Technically the fact that https://github.com/nimblehq/centauri-web is deployed onto Heroku is the proof of work 👉 https://centauri-staging.nimblehq.co/