### PR TITLE
Add `Upload Code Coverage Artifact` step to Github Action Test workflow

### DIFF
--- a/priv/templates/nimble_template/.github/workflows/test.yml.eex
+++ b/priv/templates/nimble_template/.github/workflows/test.yml.eex
@@ -86,8 +86,16 @@ jobs:
 
       - name: Run Tests
         run: mix coverage
+      
+      - name: Upload Code Coverage Artifact
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: code_coverage
+          path: cover/
       <%= if web_project? do %>
-      - uses: actions/upload-artifact@v2
+      - name: Upload Wallaby Screenshots Artifact
+        uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
           name: wallaby_screenshots

--- a/priv/templates/nimble_template/.github/workflows/test.yml.mix.eex
+++ b/priv/templates/nimble_template/.github/workflows/test.yml.mix.eex
@@ -47,3 +47,10 @@ jobs:
 
       - name: Run Tests
         run: mix coverage
+        
+      - name: Upload Code Coverage Artifacts 
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: code_coverage
+          path: cover/

--- a/priv/templates/nimble_template/.github/workflows/test.yml.mix.eex
+++ b/priv/templates/nimble_template/.github/workflows/test.yml.mix.eex
@@ -48,7 +48,7 @@ jobs:
       - name: Run Tests
         run: mix coverage
         
-      - name: Upload Code Coverage Artifacts 
+      - name: Upload Code Coverage Artifact
         uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:


### PR DESCRIPTION
## What happened

Upload the Upload Code Coverage Artifact
 
## Insight

It helps developers to detect which method is not covered by the test suite yet by downloading the artifact
 
## Proof Of Work

Already tested on the real project.

![image](https://user-images.githubusercontent.com/11751745/123629002-efa36680-d83d-11eb-8211-6003508836b1.png)

