### PR TITLE
Order mix dependencies

### DIFF
--- a/lib/nimble_template/helpers/dependency.ex
+++ b/lib/nimble_template/helpers/dependency.ex
@@ -1,5 +1,34 @@
 defmodule NimbleTemplate.DependencyHelper do
-  def fetch_and_install_dependencies(),
+  alias NimbleTemplate.Generator
+
+  def fetch_and_install_dependencies,
     do:
       if(Mix.shell().yes?("\nFetch and install dependencies?"), do: Mix.shell().cmd("mix deps.get"))
+
+  def order_dependencies! do
+    file_content = File.read!("mix.exs")
+
+    dependencies = extract_dependencies(file_content)
+
+    ordered_dependencies =
+      dependencies
+      |> String.split(",\n")
+      |> Enum.sort()
+      |> Enum.join(",\n")
+
+    Generator.replace_content("mix.exs", dependencies, ordered_dependencies)
+  end
+
+  def extract_dependencies(contents) do
+    [_, deps_with_tail] =
+      :binary.split(contents, """
+        defp deps do
+          [
+      """)
+
+    [deps, _tail] =
+      :binary.split(deps_with_tail, "\n    ]\n  end")
+
+    deps
+  end
 end

--- a/lib/nimble_template/helpers/dependency.ex
+++ b/lib/nimble_template/helpers/dependency.ex
@@ -20,13 +20,13 @@ defmodule NimbleTemplate.DependencyHelper do
   end
 
   def extract_dependencies(contents) do
-    [_, deps_with_tail] =
+    [_, deps_with_file_footer] =
       :binary.split(contents, """
         defp deps do
           [
       """)
 
-    [deps, _tail] = :binary.split(deps_with_tail, "\n    ]\n  end")
+    [deps, _footer] = :binary.split(deps_with_file_footer, "\n    ]\n  end")
 
     deps
   end

--- a/lib/nimble_template/helpers/dependency.ex
+++ b/lib/nimble_template/helpers/dependency.ex
@@ -21,12 +21,12 @@ defmodule NimbleTemplate.DependencyHelper do
 
   defp extract_dependencies(contents) do
     [_, deps_with_file_footer] =
-      :binary.split(contents, """
+      String.split(contents, """
         defp deps do
           [
       """)
 
-    [deps, _footer] = :binary.split(deps_with_file_footer, "\n    ]\n  end")
+    [deps | _footer] = String.split(deps_with_file_footer, "\n    ]\n  end")
 
     deps
   end

--- a/lib/nimble_template/helpers/dependency.ex
+++ b/lib/nimble_template/helpers/dependency.ex
@@ -19,7 +19,7 @@ defmodule NimbleTemplate.DependencyHelper do
     Generator.replace_content("mix.exs", dependencies, ordered_dependencies)
   end
 
-  def extract_dependencies(contents) do
+  defp extract_dependencies(contents) do
     [_, deps_with_file_footer] =
       :binary.split(contents, """
         defp deps do

--- a/lib/nimble_template/helpers/dependency.ex
+++ b/lib/nimble_template/helpers/dependency.ex
@@ -26,8 +26,7 @@ defmodule NimbleTemplate.DependencyHelper do
           [
       """)
 
-    [deps, _tail] =
-      :binary.split(deps_with_tail, "\n    ]\n  end")
+    [deps, _tail] = :binary.split(deps_with_tail, "\n    ]\n  end")
 
     deps
   end

--- a/lib/nimble_template/template.ex
+++ b/lib/nimble_template/template.ex
@@ -10,12 +10,14 @@ defmodule NimbleTemplate.Template do
   def apply(%Project{mix_project?: true} = project) do
     MixTemplate.apply(project)
 
+    order_dependencies!()
     fetch_and_install_dependencies()
   end
 
   def apply(%Project{} = project) do
     PhoenixTemplate.apply(project)
 
+    order_dependencies!()
     fetch_and_install_dependencies()
   end
 end

--- a/test/nimble_template/helpers/dependency_test.exs
+++ b/test/nimble_template/helpers/dependency_test.exs
@@ -4,8 +4,7 @@ defmodule NimbleTemplate.DependencyTest do
   alias NimbleTemplate.{Addons, DependencyHelper}
 
   describe "order_dependencies!/0" do
-    @describetag mock_latest_package_versions: [{:exvcr, "0.12.2"}]
-    @describetag mock_latest_package_versions: [{:mimic, "1.3.1"}]
+    @describetag mock_latest_package_versions: [{:exvcr, "0.12.2"}, {:mimic, "1.3.1"}]
 
     test "orders dependencies in alphabetical order", %{
       project: project,

--- a/test/nimble_template/helpers/dependency_test.exs
+++ b/test/nimble_template/helpers/dependency_test.exs
@@ -1,0 +1,32 @@
+defmodule NimbleTemplate.DependencyTest do
+  use NimbleTemplate.AddonCase, async: false
+
+  alias NimbleTemplate.{Addons, DependencyHelper}
+
+  describe "order_dependencies!/0" do
+    @describetag mock_latest_package_versions: [{:exvcr, "0.12.2"}]
+    @describetag mock_latest_package_versions: [{:mimic, "1.3.1"}]
+
+    test "orders dependencies in alphabetical order", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        Addons.ExVCR.apply(project)
+        Addons.Mimic.apply(project)
+
+        # Unordered mix dependencies
+        assert_file("mix.exs", fn file ->
+          assert file =~ ~r/(:mimic).*(:exvcr)/s
+        end)
+
+        DependencyHelper.order_dependencies!()
+
+        # Ordered mix dependencies
+        assert_file("mix.exs", fn file ->
+          assert file =~ ~r/(:exvcr).*(:mimic)/s
+        end)
+      end)
+    end
+  end
+end


### PR DESCRIPTION
## What happened

Order dependencies in `mix.exs` in alphabetical order
 
## Proof Of Work

Setup project with the template, all dependencies are properly ordered.
![image](https://user-images.githubusercontent.com/14077479/133728212-419ba93d-38f0-4792-8eda-d7a9c5dc08e4.png)

