### PR TITLE
Skip node dependencies installation for API variant

### DIFF
--- a/.github/workflows/test_api_variant_on_custom_api_project.yml
+++ b/.github/workflows/test_api_variant_on_custom_api_project.yml
@@ -48,7 +48,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-
 
-      - uses: nimblehq/elixir-templates@composite_1.4
+      - uses: nimblehq/elixir-templates@composite_1.5
         with:
           new_project_options: '--no-html --no-webpack --module=CustomModule --app=custom_app'
           variant: 'api'

--- a/.github/workflows/test_api_variant_on_standard_api_project.yml
+++ b/.github/workflows/test_api_variant_on_standard_api_project.yml
@@ -48,7 +48,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-
 
-      - uses: nimblehq/elixir-templates@composite_1.4
+      - uses: nimblehq/elixir-templates@composite_1.5
         with:
           new_project_options: '--no-html --no-webpack'
           variant: 'api'

--- a/.github/workflows/test_live_variant_on_custom_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_custom_liveview_project.yml
@@ -62,7 +62,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - uses: nimblehq/elixir-templates@composite_1.4
+      - uses: nimblehq/elixir-templates@composite_1.5
         with:
           new_project_options: '--live --module=CustomModule --app=custom_app'
           variant: 'live'

--- a/.github/workflows/test_live_variant_on_standard_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_standard_liveview_project.yml
@@ -62,7 +62,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - uses: nimblehq/elixir-templates@composite_1.4
+      - uses: nimblehq/elixir-templates@composite_1.5
         with:
           new_project_options: '--live'
           variant: 'live'

--- a/.github/workflows/test_variant_on_custom_web_project.yml
+++ b/.github/workflows/test_variant_on_custom_web_project.yml
@@ -66,7 +66,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - uses: nimblehq/elixir-templates@composite_1.4
+      - uses: nimblehq/elixir-templates@composite_1.5
         with:
           new_project_options: '--module=CustomModule --app=custom_app'
           variant: ${{ matrix.variant }}

--- a/.github/workflows/test_variant_on_standard_web_project.yml
+++ b/.github/workflows/test_variant_on_standard_web_project.yml
@@ -66,7 +66,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - uses: nimblehq/elixir-templates@composite_1.4
+      - uses: nimblehq/elixir-templates@composite_1.5
         with:
           new_project_options: ''
           variant: ${{ matrix.variant }}

--- a/action.yml
+++ b/action.yml
@@ -35,13 +35,10 @@ runs:
         MIX_ENV: test
 
     - name: Install Node Dependencies
-      run: |
-            cd sample_project 
-            if [ -f assets/package.json ]; then
-              npm install --prefix assets
-            else 
-              echo package.json does not exist, skipping node dependencies installation.
-            fi
+      env: 
+        VARIANT_WITHOUT_NODE: '["api"]'
+      if: contains(fromJson(env.VARIANT_WITHOUT_NODE), inputs.variant) != true
+      run: cd sample_project && npm install --prefix assets
       shell: bash
 
     - name: Run mix ecto.create

--- a/action.yml
+++ b/action.yml
@@ -33,10 +33,15 @@ runs:
       shell: bash
       env:
         MIX_ENV: test
-      
+
     - name: Install Node Dependencies
-      if: (test -f sample_project/assets/package.json)
-      run: cd sample_project && npm install --prefix assets
+      run: |
+            cd sample_project 
+            if [ -f assets/package.json ]; then
+              npm install --prefix assets
+            else 
+              echo package.json does not exist, skipping node dependencies installation.
+            fi
       shell: bash
 
     - name: Run mix ecto.create

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,7 @@ runs:
         MIX_ENV: test
       
     - name: Install Node Dependencies
+      if: (test -f sample_project/assets/package.json)
       run: cd sample_project && npm install --prefix assets
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -36,8 +36,8 @@ runs:
 
     - name: Install Node Dependencies
       env: 
-        VARIANT_WITHOUT_NODE: '["api"]'
-      if: contains(fromJson(env.VARIANT_WITHOUT_NODE), inputs.variant) != true
+        VARIANT_WITH_NODE_DEPENDENCY: '["web", "live"]'
+      if: contains(fromJson(env.VARIANT_WITH_NODE_DEPENDENCY), inputs.variant) == true
       run: cd sample_project && npm install --prefix assets
       shell: bash
 


### PR DESCRIPTION
## What happened

- CI is failing when running setup on API variants because these variants do not have `package.json`
![image](https://user-images.githubusercontent.com/14077479/144979367-46c2b4ff-d90a-4ba6-aeb6-a971321f91e9.png)
 
- Solve the issue by installing node dependencies only when `package.json` exists.

## Proof Of Work

CI passed ✅
