### PR TITLE
Add Param Validation for the API project

### DIFF
--- a/.github/workflows/test_api_variant_on_custom_api_project.yml
+++ b/.github/workflows/test_api_variant_on_custom_api_project.yml
@@ -54,5 +54,5 @@ jobs:
       - name: Run composite steps
         uses: nimblehq/elixir-templates@composite_1.5
         with:
-          new_project_options: '--no-html --no-webpack --module=CustomModule --app=custom_app'
+          new_project_options: '--no-html --no-webpack --module=SampleCustomModule --app=sample_custom_app'
           variant: 'api'

--- a/.github/workflows/test_live_variant_on_custom_liveview_project.yml
+++ b/.github/workflows/test_live_variant_on_custom_liveview_project.yml
@@ -69,5 +69,5 @@ jobs:
       - name: Run composite steps
         uses: nimblehq/elixir-templates@composite_1.4
         with:
-          new_project_options: '--live --module=CustomModule --app=custom_app'
+          new_project_options: '--live --module=SampleCustomModule --app=sample_custom_app'
           variant: 'live'

--- a/.github/workflows/test_mix_variant_on_custom_mix_project.yml
+++ b/.github/workflows/test_mix_variant_on_custom_mix_project.yml
@@ -40,7 +40,7 @@ jobs:
             ${{ runner.os }}-mix-
 
       - name: Create Mix project
-        run: make create_mix_project PROJECT_DIRECTORY=sample_project OPTIONS="--module=CustomModule --app=custom_app"
+        run: make create_mix_project PROJECT_DIRECTORY=sample_project OPTIONS="--module=CustomModule --app=sample_custom_app"
 
       - name: Apply Mix template
         run: make apply_mix_template PROJECT_DIRECTORY=sample_project

--- a/.github/workflows/test_mix_variant_on_custom_mix_project_with_supervision.yml
+++ b/.github/workflows/test_mix_variant_on_custom_mix_project_with_supervision.yml
@@ -40,7 +40,7 @@ jobs:
             ${{ runner.os }}-mix-
 
       - name: Create Mix project
-        run: make create_mix_project PROJECT_DIRECTORY=sample_project OPTIONS="--module=CustomModule --app=custom_app --sup"
+        run: make create_mix_project PROJECT_DIRECTORY=sample_project OPTIONS="--module=SampleCustomModule --app=sample_custom_app --sup"
 
       - name: Apply Mix template
         run: make apply_mix_template PROJECT_DIRECTORY=sample_project

--- a/.github/workflows/test_variant_on_custom_web_project.yml
+++ b/.github/workflows/test_variant_on_custom_web_project.yml
@@ -73,5 +73,5 @@ jobs:
       - name: Run composite steps
         uses: nimblehq/elixir-templates@composite_1.4
         with:
-          new_project_options: '--module=CustomModule --app=custom_app'
+          new_project_options: '--module=SampleCustomModule --app=sample_custom_app'
           variant: ${{ matrix.variant }}

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ All test files are located under `test/` directory.
 
 #### 2.1/ Variant
 
-NimbleTemplate supports 4 variants:  
+NimbleTemplate supports 4 variants:
 
 - API
 - Live
@@ -132,29 +132,29 @@ mix phx.new awesome_project --no-html --no-webpack
 - Custom project variant allow us to modify the app name or module name.
 
 ```bash
-# Use CustomModuleName
-mix phx.new awesome_project --module=CustomModuleName
+# Use SampleCustomModuleName
+mix phx.new awesome_project --module=SampleCustomModuleName
 
 # Use custom OTP app name
-mix phx.new awesome_project --app=custom_otp_app_name
+mix phx.new awesome_project --app=sample_custom_otp_app_name
 
 # Use custom module and app name
-mix phx.new awesome_project --module=CustomModuleName --app=custom_otp_app_name
+mix phx.new awesome_project --module=SampleCustomModuleName --app=sample_custom_otp_app_name
 ```
 
 So it ends up with 6 project types:
 
-Web project 
+Web project
 - Standard (`mix phx.new awesome_project`)
-- Custom (`mix phx.new awesome_project --module=CustomModuleName --app=custom_otp_app_name`)
+- Custom (`mix phx.new awesome_project --module=SampleCustomModuleName --app=sample_custom_otp_app_name`)
 
 API project
 - Standard (`mix phx.new awesome_project --no-html --no-webpack`)
-- Custom (`mix phx.new awesome_project --no-html --no-webpack --module=CustomModuleName --app=custom_otp_app_name`)
+- Custom (`mix phx.new awesome_project --no-html --no-webpack --module=SampleCustomModuleName --app=sample_custom_otp_app_name`)
 
 LiveView project
 - Standard (`mix phx.new awesome_project --live`)
-- Custom (`mix phx.new awesome_project --live --module=CustomModuleName --app=custom_otp_app_name`)
+- Custom (`mix phx.new awesome_project --live --module=SampleCustomModuleName --app=sample_custom_otp_app_name`)
 
 Putting it all together, there are 8 variants of test cases.
 
@@ -172,16 +172,16 @@ Putting it all together, there are 8 variants of test cases.
 The Mix project could be either a Standard project or a Custom project.
 
 - `mix new awesome_project`
-- `mix new awesome_project --module=CustomModuleName`
-- `mix new awesome_project --app=custom_otp_app_name`
-- `mix new awesome_project --module=CustomModuleName --app=custom_otp_app_name`
+- `mix new awesome_project --module=SampleCustomModuleName`
+- `mix new awesome_project --app=sample_custom_otp_app_name`
+- `mix new awesome_project --module=SampleCustomModuleName --app=sample_custom_otp_app_name`
 
 Each project could be include the `supervision tree` or not.
 
 - `mix new awesome_project`
 - `mix new awesome_project --sup`
-- `mix new awesome_project --module=CustomModuleName --app=custom_otp_app_name`
-- `mix new awesome_project --module=CustomModuleName --app=custom_otp_app_name --sup`
+- `mix new awesome_project --module=SampleCustomModuleName --app=sample_custom_otp_app_name`
+- `mix new awesome_project --module=SampleCustomModuleName --app=sample_custom_otp_app_name --sup`
 
 Putting it all together, it will has 4 variant test cases.
 
@@ -203,7 +203,7 @@ Once the release branch is merged into the `master` branch, Github Action automa
 
 ## Contributing
 
-Contributions, issues, and feature requests are welcome!<br />Feel free to check [issues page](https://github.com/nimblehq/elixir-templates/issues). 
+Contributions, issues, and feature requests are welcome!<br />Feel free to check [issues page](https://github.com/nimblehq/elixir-templates/issues).
 
 ## License
 

--- a/lib/nimble_template/addons/variants/phoenix/api/params_validation.ex
+++ b/lib/nimble_template/addons/variants/phoenix/api/params_validation.ex
@@ -1,0 +1,32 @@
+defmodule NimbleTemplate.Addons.Phoenix.Api.ParamsValidation do
+  @moduledoc false
+
+  use NimbleTemplate.Addon
+
+  def do_apply(%Project{} = project, _opts) do
+    project
+    |> copy_files()
+  end
+
+  defp copy_files(
+         %Project{web_module: web_module, base_module: base_module, web_test_path: web_test_path} =
+           project
+       ) do
+    binding = [
+      web_module: web_module,
+      base_module: base_module
+    ]
+
+    files = [
+      {:eex, "lib/otp_app_web/params/params.ex.eex", "#{web_module}/params/params.ex"},
+      {:eex, "lib/otp_app_web/params/params_validator.ex.eex",
+       "#{web_module}/params/params_validator.ex"},
+      {:eex, "test/otp_app_web/params/params_validator_test.exs.eex",
+       "test/#{web_test_path}/params/params_validator_test.exs"}
+    ]
+
+    Generator.copy_file(files, binding)
+
+    project
+  end
+end

--- a/lib/nimble_template/addons/variants/phoenix/api/params_validation.ex
+++ b/lib/nimble_template/addons/variants/phoenix/api/params_validation.ex
@@ -9,8 +9,12 @@ defmodule NimbleTemplate.Addons.Phoenix.Api.ParamsValidation do
   end
 
   defp copy_files(
-         %Project{web_module: web_module, base_module: base_module, web_test_path: web_test_path} =
-           project
+         %Project{
+           web_module: web_module,
+           web_path: web_path,
+           base_module: base_module,
+           web_test_path: web_test_path
+         } = project
        ) do
     binding = [
       web_module: web_module,
@@ -18,11 +22,11 @@ defmodule NimbleTemplate.Addons.Phoenix.Api.ParamsValidation do
     ]
 
     files = [
-      {:eex, "lib/otp_app_web/params/params.ex.eex", "#{web_module}/params/params.ex"},
+      {:eex, "lib/otp_app_web/params/params.ex.eex", "#{web_path}/params/params.ex"},
       {:eex, "lib/otp_app_web/params/params_validator.ex.eex",
-       "#{web_module}/params/params_validator.ex"},
+       "#{web_path}/params/params_validator.ex"},
       {:eex, "test/otp_app_web/params/params_validator_test.exs.eex",
-       "test/#{web_test_path}/params/params_validator_test.exs"}
+       "#{web_test_path}/params/params_validator_test.exs"}
     ]
 
     Generator.copy_file(files, binding)

--- a/lib/nimble_template/addons/variants/phoenix/api/params_validation.ex
+++ b/lib/nimble_template/addons/variants/phoenix/api/params_validation.ex
@@ -3,16 +3,13 @@ defmodule NimbleTemplate.Addons.Phoenix.Api.ParamsValidation do
 
   use NimbleTemplate.Addon
 
-  def do_apply(%Project{} = project, _opts) do
-    project
-    |> copy_files()
-  end
+  def do_apply(%Project{} = project, _opts), do: copy_files(project)
 
   defp copy_files(
          %Project{
+           base_module: base_module,
            web_module: web_module,
            web_path: web_path,
-           base_module: base_module,
            web_test_path: web_test_path
          } = project
        ) do

--- a/lib/nimble_template/variants/phoenix/api/template.ex
+++ b/lib/nimble_template/variants/phoenix/api/template.ex
@@ -5,8 +5,8 @@ defmodule NimbleTemplate.Phoenix.Api.Template do
   alias NimbleTemplate.Project
 
   def apply(%Project{} = project) do
-    Api.Config.apply(project)
-
     project
+    |> Api.Config.apply()
+    |> Api.ParamsValidation.apply()
   end
 end

--- a/priv/templates/nimble_template/.credo.exs
+++ b/priv/templates/nimble_template/.credo.exs
@@ -87,7 +87,7 @@
         # If you don't want TODO comments to cause `mix credo` to fail, just
         # set this value to 0 (zero).
         #
-        {Credo.Check.Design.TagTODO, [exit_status: 2]},
+        {Credo.Check.Design.TagTODO, [exit_status: 0]},
         {Credo.Check.Design.TagFIXME, []},
 
         #
@@ -161,9 +161,9 @@
            order:
              ~w/shortdoc moduledoc behaviour use import alias require module_attribute defstruct callback/a
          ]},
-        {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
         {Credo.Check.Consistency.UnusedVariableNames, false},
-        {Credo.Check.Design.DuplicatedCode, []},
+        {Credo.Check.Design.DuplicatedCode, files: %{excluded: ["**/*_test.exs"]}},
         {Credo.Check.Readability.AliasAs, false},
         {Credo.Check.Readability.MultiAlias, false},
         {Credo.Check.Readability.Specs, false},

--- a/priv/templates/nimble_template/.credo.exs
+++ b/priv/templates/nimble_template/.credo.exs
@@ -161,7 +161,7 @@
            order:
              ~w/shortdoc moduledoc behaviour use import alias require module_attribute defstruct callback/a
          ]},
-        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
         {Credo.Check.Consistency.UnusedVariableNames, false},
         {Credo.Check.Design.DuplicatedCode, files: %{excluded: ["**/*_test.exs"]}},
         {Credo.Check.Readability.AliasAs, false},

--- a/priv/templates/nimble_template/lib/otp_app_web/params/params.ex.eex
+++ b/priv/templates/nimble_template/lib/otp_app_web/params/params.ex.eex
@@ -1,0 +1,21 @@
+defmodule <%= base_module %>.Params do
+  @moduledoc """
+  Apply to the params module to define params schema with validation.
+  """
+
+  @callback changeset(map(), map()) :: Ecto.Changeset.t()
+  @optional_callbacks [changeset: 2]
+
+  @type t :: module
+
+  defmacro __using__(_) do
+    quote do
+      use Ecto.Schema
+      import Ecto.Changeset
+
+      @primary_key false
+
+      @behaviour <%= base_module %>.Params
+    end
+  end
+end

--- a/priv/templates/nimble_template/lib/otp_app_web/params/params.ex.eex
+++ b/priv/templates/nimble_template/lib/otp_app_web/params/params.ex.eex
@@ -1,4 +1,4 @@
-defmodule <%= base_module %>Web.Params do
+defmodule <%= web_module %>.Params do
   @moduledoc """
   Apply to the params module to define params schema with validation.
   """
@@ -17,7 +17,7 @@ defmodule <%= base_module %>Web.Params do
 
       @primary_key false
 
-      @behaviour <%= base_module %>Web.Params
+      @behaviour <%= web_module %>.Params
     end
   end
 end

--- a/priv/templates/nimble_template/lib/otp_app_web/params/params.ex.eex
+++ b/priv/templates/nimble_template/lib/otp_app_web/params/params.ex.eex
@@ -17,7 +17,7 @@ defmodule <%= base_module %>Web.Params do
 
       @primary_key false
 
-      @behaviour <%= base_module %>.Params
+      @behaviour <%= base_module %>Web.Params
     end
   end
 end

--- a/priv/templates/nimble_template/lib/otp_app_web/params/params.ex.eex
+++ b/priv/templates/nimble_template/lib/otp_app_web/params/params.ex.eex
@@ -1,9 +1,10 @@
-defmodule <%= base_module %>.Params do
+defmodule <%= base_module %>Web.Params do
   @moduledoc """
   Apply to the params module to define params schema with validation.
   """
 
   @callback changeset(map(), map()) :: Ecto.Changeset.t()
+
   @optional_callbacks [changeset: 2]
 
   @type t :: module
@@ -11,6 +12,7 @@ defmodule <%= base_module %>.Params do
   defmacro __using__(_) do
     quote do
       use Ecto.Schema
+
       import Ecto.Changeset
 
       @primary_key false

--- a/priv/templates/nimble_template/lib/otp_app_web/params/params_validator.ex.eex
+++ b/priv/templates/nimble_template/lib/otp_app_web/params/params_validator.ex.eex
@@ -1,0 +1,34 @@
+defmodule <%= base_module %>.ParamsValidator do
+  @moduledoc """
+  Helper module for validating given request params with params module
+  """
+
+  alias Ecto.Changeset
+  alias <%= base_module %>.Params
+
+  @spec validate(map(), atom(), [{:for, Params.t()}]) ::
+          {:ok, map()} | {:error, :invalid_params, Ecto.Changeset.t()}
+  def validate(params, changeset_method \\ :changeset, for: params_module) do
+    params_module
+    |> Kernel.apply(changeset_method, [params])
+    |> handle_changeset()
+  end
+
+  defp handle_changeset(%Changeset{valid?: true} = changeset),
+    do: {:ok, extract_changes(changeset)}
+
+  defp handle_changeset(changeset), do: {:error, :invalid_params, put_action(changeset)}
+
+  defp extract_changes(%Changeset{} = changeset) do
+    Enum.reduce(changeset.changes, %{}, fn {key, value}, params ->
+      Map.put(params, key, extract_changes(value))
+    end)
+  end
+
+  defp extract_changes([%Changeset{} | _] = changesets),
+    do: Enum.map(changesets, &extract_changes/1)
+
+  defp extract_changes(value), do: value
+
+  defp put_action(%Changeset{} = changeset), do: Map.put(changeset, :action, :validate)
+end

--- a/priv/templates/nimble_template/lib/otp_app_web/params/params_validator.ex.eex
+++ b/priv/templates/nimble_template/lib/otp_app_web/params/params_validator.ex.eex
@@ -3,8 +3,8 @@ defmodule <%= base_module %>Web.ParamsValidator do
   Helper module for validating given request params with params module
   """
 
-  alias <%= base_module %>Web.Params
   alias Ecto.Changeset
+  alias <%= base_module %>Web.Params
 
   @spec validate(map(), atom(), [{:for, Params.t()}]) ::
           {:ok, map()} | {:error, :invalid_params, Ecto.Changeset.t()}

--- a/priv/templates/nimble_template/lib/otp_app_web/params/params_validator.ex.eex
+++ b/priv/templates/nimble_template/lib/otp_app_web/params/params_validator.ex.eex
@@ -3,7 +3,7 @@ defmodule <%= base_module %>Web.ParamsValidator do
   Helper module for validating given request params with params module
   """
 
-  alias <%= base_module %>.Params
+  alias <%= base_module %>Web.Params
   alias Ecto.Changeset
 
   @spec validate(map(), atom(), [{:for, Params.t()}]) ::

--- a/priv/templates/nimble_template/lib/otp_app_web/params/params_validator.ex.eex
+++ b/priv/templates/nimble_template/lib/otp_app_web/params/params_validator.ex.eex
@@ -1,10 +1,10 @@
-defmodule <%= base_module %>.ParamsValidator do
+defmodule <%= base_module %>Web.ParamsValidator do
   @moduledoc """
   Helper module for validating given request params with params module
   """
 
-  alias Ecto.Changeset
   alias <%= base_module %>.Params
+  alias Ecto.Changeset
 
   @spec validate(map(), atom(), [{:for, Params.t()}]) ::
           {:ok, map()} | {:error, :invalid_params, Ecto.Changeset.t()}

--- a/priv/templates/nimble_template/lib/otp_app_web/params/params_validator.ex.eex
+++ b/priv/templates/nimble_template/lib/otp_app_web/params/params_validator.ex.eex
@@ -1,10 +1,10 @@
-defmodule <%= base_module %>Web.ParamsValidator do
+defmodule <%= web_module %>.ParamsValidator do
   @moduledoc """
   Helper module for validating given request params with params module
   """
 
   alias Ecto.Changeset
-  alias <%= base_module %>Web.Params
+  alias <%= web_module %>.Params
 
   @spec validate(map(), atom(), [{:for, Params.t()}]) ::
           {:ok, map()} | {:error, :invalid_params, Ecto.Changeset.t()}

--- a/priv/templates/nimble_template/test/otp_app_web/params/params_validator_test.exs.eex
+++ b/priv/templates/nimble_template/test/otp_app_web/params/params_validator_test.exs.eex
@@ -1,10 +1,10 @@
-defmodule <%= base_module %>Web.ParamsValidatorTest do
+defmodule <%= web_module %>.ParamsValidatorTest do
   use <%= base_module %>.DataCase, async: true
 
-  alias <%= base_module %>Web.ParamsValidator
+  alias <%= web_module %>.ParamsValidator
 
   defmodule CreateDeviceParams do
-    use <%= base_module %>Web.Params
+    use <%= web_module %>.Params
 
     embedded_schema do
       field(:device_id, :string)
@@ -25,7 +25,7 @@ defmodule <%= base_module %>Web.ParamsValidatorTest do
   end
 
   defmodule CreateUserParams do
-    use <%= base_module %>Web.Params
+    use <%= web_module %>.Params
 
     embedded_schema do
       field(:name, :string)

--- a/priv/templates/nimble_template/test/otp_app_web/params/params_validator_test.exs.eex
+++ b/priv/templates/nimble_template/test/otp_app_web/params/params_validator_test.exs.eex
@@ -1,0 +1,104 @@
+defmodule <%= base_module %>Web.ParamsValidatorTest do
+  use <%= base_module %>.DataCase, async: true
+
+  alias <%= base_module %>Web.ParamsValidator
+
+  defmodule CreateDeviceParams do
+    use <%= base_module %>Web.Params
+
+    embedded_schema do
+      field(:device_id, :string)
+      field(:device_name, :string)
+    end
+
+    def changeset(data \\ %__MODULE__{}, params) do
+      data
+      |> cast(params, [:device_id, :device_name])
+      |> validate_required([:device_id, :device_name])
+    end
+
+    def custom_changeset(data \\ %__MODULE__{}, params) do
+      data
+      |> cast(params, [:device_id, :device_name])
+      |> validate_required([:device_id])
+    end
+  end
+
+  defmodule CreateUserParams do
+    use <%= base_module %>Web.Params
+
+    embedded_schema do
+      field(:name, :string)
+      embeds_many(:devices, CreateDeviceParams)
+    end
+
+    def changeset(data \\ %__MODULE__{}, params) do
+      data
+      |> cast(params, [:name])
+      |> cast_embed(:devices, required: true)
+      |> validate_required([:name])
+    end
+  end
+
+  describe "validate/2" do
+    test "given valid params, returns {:ok, validated_params}" do
+      params = %{
+        "name" => "John Doe",
+        "devices" => [
+          %{
+            "device_id" => "Android",
+            "device_name" => "John Doe Devices"
+          }
+        ]
+      }
+
+      assert {:ok, validated_params} = ParamsValidator.validate(params, for: CreateUserParams)
+
+      assert validated_params == %{
+               devices: [%{device_id: "Android", device_name: "John Doe Devices"}],
+               name: "John Doe"
+             }
+    end
+
+    test "given valid params for the custom_changeset, returns {:ok, validated_params} " do
+      params = %{
+        "device_id" => "Android",
+        "device_name" => "John Doe Devices"
+      }
+
+      assert {:ok, validated_params} =
+               ParamsValidator.validate(params, :custom_changeset, for: CreateDeviceParams)
+
+      assert validated_params == %{
+               device_id: "Android",
+               device_name: "John Doe Devices"
+             }
+    end
+
+    test "given invalid params, returns {:error, :invalid_params, changeset}" do
+      params = %{"device_id" => ""}
+
+      assert {:error, :invalid_params, changeset} =
+               ParamsValidator.validate(params, for: CreateUserParams)
+
+      assert changeset.valid? == false
+      assert changeset.action == :validate
+
+      assert errors_on(changeset) == %{devices: ["can't be blank"], name: ["can't be blank"]}
+    end
+
+    test "given invalid params for the custom_changeset, returns {:error, :invalid_params, changeset}" do
+      params = %{"device_id" => ""}
+
+      assert {:error, :invalid_params, changeset} =
+               ParamsValidator.validate(params, :custom_changeset, for: CreateDeviceParams)
+
+      assert changeset.valid? == false
+      assert changeset.action == :validate
+
+      assert errors_on(changeset) == %{
+               device_id: ["can't be blank"]
+             }
+    end
+  end
+end

--- a/test/nimble_template/addons/variants/phoenix/api/params_validation_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/api/params_validation_test.exs
@@ -1,0 +1,18 @@
+defmodule NimbleTemplate.Addons.Phoenix.Api.ParamsValidationTest do
+  use NimbleTemplate.AddonCase, async: false
+
+  describe "#apply/2" do
+    test "copies the params validation module and test files", %{
+      project: project,
+      test_project_path: project_path
+    } do
+      in_test_project(project_path, fn ->
+        AddonsApi.ParamsValidation.apply(project)
+
+        assert_file("lib/nimble_template_web/params/params.ex")
+        assert_file("lib/nimble_template_web/params/params_validator.ex")
+        assert_file("test/nimble_template_web/params/params_validator_test.exs")
+      end)
+    end
+  end
+end

--- a/test/support/addon_case.ex
+++ b/test/support/addon_case.ex
@@ -3,6 +3,7 @@ defmodule NimbleTemplate.AddonCase do
 
   use Mimic
 
+  alias NimbleTemplate.Addons.Phoenix.Api, as: AddonsApi
   alias NimbleTemplate.Addons.Phoenix.Web, as: AddonsWeb
   alias NimbleTemplate.{Addons, Project}
   alias NimbleTemplate.Hex.Package


### PR DESCRIPTION
https://github.com/nimblehq/elixir-templates/issues/127

## What happened

- Implement setup Param validation for API projects. I will implement add error view in another PR.
 
⚠️  Notice: 
in this pull request, I renamed the `CustomModule` to `SampleCustomModule` and `custom_app` to `sample_custom_app` to make the name of the module consistent alphabetically with `sample_project`. In case we add a pre-defined alias module we will not have an issue with the Credo check for sorting the alias alphabetically warning.

![Screen Shot 2021-12-22 at 11 00 57 AM](https://user-images.githubusercontent.com/948856/147033547-1aee2a92-a8cd-4e84-98ce-257d4d5ee583.png)


## Insight

- [x] Add param validations
- [x] Update the `.credo.exs` config of the output template.
  - [x] Allow `TODO` comment with exit code zero
  - [x] Disable check duplicated code in `tests`

## Proof Of Work

The test should pass.