### PR TITLE
Use nimble workflow for the publish wiki action

### DIFF
--- a/priv/templates/nimble_template/.github/workflows/publish_wiki.yml
+++ b/priv/templates/nimble_template/.github/workflows/publish_wiki.yml
@@ -11,41 +11,13 @@ env:
   USER_TOKEN: ${{ secrets.GH_TOKEN }}
   USER_NAME: github-wiki-workflow
   USER_EMAIL: ${{ secrets.GH_EMAIL }}
-  OWNER: ${{ github.event.repository.owner.name }}
-  REPOSITORY_NAME: ${{ github.event.repository.name }}
-  WIKI_FOLDER: .github/wiki
-  TEMP_CLONE_WIKI_FOLDER: tmp_wiki
 
 jobs:
   publish:
-    name: Publish Github Wiki
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-
-    steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.8.0
-        with:
-          access_token: ${{ github.token }}
-
-      - name: Checkout the repository
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
-
-      - name: Pull current wiki content
-        run: |
-          mkdir $TEMP_CLONE_WIKI_FOLDER
-          cd $TEMP_CLONE_WIKI_FOLDER
-          git init
-          git config user.name $USER_NAME
-          git config user.email $USER_EMAIL
-          git pull https://$USER_TOKEN@github.com/$OWNER/$REPOSITORY_NAME.wiki.git
-
-      - name: Push new wiki content
-        run: |
-          rsync -av --delete $WIKI_FOLDER/ $TEMP_CLONE_WIKI_FOLDER/ --exclude .git
-          cd $TEMP_CLONE_WIKI_FOLDER
-          git add .
-          git commit -m "Update Wiki content"
-          git push -f --set-upstream https://$USER_TOKEN@github.com/$OWNER/$REPOSITORY_NAME.wiki.git master
+    name: Publish Wiki
+    uses: nimblehq/github-actions-workflows/.github/workflows/publish_wiki.yml@0.1.0
+    with:
+      USER_NAME: $USER_NAME
+      USER_EMAIL: $USER_EMAIL
+    secrets:
+      USER_TOKEN: $USER_TOKEN

--- a/priv/templates/nimble_template/.github/workflows/publish_wiki.yml
+++ b/priv/templates/nimble_template/.github/workflows/publish_wiki.yml
@@ -7,17 +7,12 @@ on:
     branches:
       - develop
 
-env:
-  USER_TOKEN: ${{ secrets.GH_TOKEN }}
-  USER_NAME: github-wiki-workflow
-  USER_EMAIL: ${{ secrets.GH_EMAIL }}
-
 jobs:
   publish:
     name: Publish Wiki
     uses: nimblehq/github-actions-workflows/.github/workflows/publish_wiki.yml@0.1.0
     with:
-      USER_NAME: $USER_NAME
-      USER_EMAIL: $USER_EMAIL
+      USER_NAME: github-wiki-workflow
+      USER_EMAIL: ${{ secrets.GH_EMAIL }}
     secrets:
-      USER_TOKEN: $USER_TOKEN
+      USER_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## What happened

Since Long published the first version for https://github.com/nimblehq/github-actions-workflows/, we now can use the `publish wiki action`
 
## Insight

Just follow the instruction https://github.com/nimblehq/github-actions-workflows/pull/1
 
## Proof Of Work

The test is passed
