### PR TITLE
Refactor the Addon modules, separate Phoenix addons vs Common MixPhoenix addons

### DIFF
--- a/.github/wiki/Testing.md
+++ b/.github/wiki/Testing.md
@@ -14,12 +14,13 @@ All test files are located under `test/` directory.
 │   ├── nimble_template
 │   │   └── addons
 │   │   │   ├── ...
-│   │   │   ├── common_addon_test.exs
+│   │   │   ├── common_mix_phoenix_addon_test.exs
 │   │   │   └── variants
 │   │   │   │   └── mix
 │   │   │   │   │   ├── ...
 │   │   │   │   │   └── mix_addon_test.exs
 │   │   │   │   └── phoenix
+│   │   │   │   │   └── common_phoenix_addon_test.exs
 │   │   │   │   │   └── api
 │   │   │   │   │   │   ├── ...
 │   │   │   │   │   │   └── api_addon_test.exs

--- a/lib/nimble_template/addons/variants/phoenix/docker.ex
+++ b/lib/nimble_template/addons/variants/phoenix/docker.ex
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.Docker do
+defmodule NimbleTemplate.Addons.Phoenix.Docker do
   @moduledoc false
 
   use NimbleTemplate.Addons.Addon

--- a/lib/nimble_template/addons/variants/phoenix/ecto_data_migration.ex
+++ b/lib/nimble_template/addons/variants/phoenix/ecto_data_migration.ex
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.EctoDataMigration do
+defmodule NimbleTemplate.Addons.Phoenix.EctoDataMigration do
   @moduledoc false
 
   use NimbleTemplate.Addons.Addon

--- a/lib/nimble_template/addons/variants/phoenix/ex_machina.ex
+++ b/lib/nimble_template/addons/variants/phoenix/ex_machina.ex
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.ExMachina do
+defmodule NimbleTemplate.Addons.Phoenix.ExMachina do
   @moduledoc false
 
   use NimbleTemplate.Addons.Addon

--- a/lib/nimble_template/addons/variants/phoenix/ex_vcr.ex
+++ b/lib/nimble_template/addons/variants/phoenix/ex_vcr.ex
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.ExVCR do
+defmodule NimbleTemplate.Addons.Phoenix.ExVCR do
   @moduledoc false
 
   use NimbleTemplate.Addons.Addon

--- a/lib/nimble_template/addons/variants/phoenix/makefile.ex
+++ b/lib/nimble_template/addons/variants/phoenix/makefile.ex
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.Makefile do
+defmodule NimbleTemplate.Addons.Phoenix.Makefile do
   @moduledoc false
 
   use NimbleTemplate.Addons.Addon

--- a/lib/nimble_template/addons/variants/phoenix/mix_release.ex
+++ b/lib/nimble_template/addons/variants/phoenix/mix_release.ex
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.MixRelease do
+defmodule NimbleTemplate.Addons.Phoenix.MixRelease do
   @moduledoc false
 
   use NimbleTemplate.Addons.Addon

--- a/lib/nimble_template/addons/variants/phoenix/oban.ex
+++ b/lib/nimble_template/addons/variants/phoenix/oban.ex
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.Oban do
+defmodule NimbleTemplate.Addons.Phoenix.Oban do
   @moduledoc false
 
   use NimbleTemplate.Addons.Addon

--- a/lib/nimble_template/templates/template.ex
+++ b/lib/nimble_template/templates/template.ex
@@ -3,6 +3,7 @@ defmodule NimbleTemplate.Templates.Template do
 
   import NimbleTemplate.DependencyHelper
 
+  alias NimbleTemplate.Addons.ExUnit
   alias NimbleTemplate.Projects.Project
   alias NimbleTemplate.Templates.Mix.Template, as: MixTemplate
   alias NimbleTemplate.Templates.Phoenix.Template, as: PhoenixTemplate
@@ -10,11 +11,15 @@ defmodule NimbleTemplate.Templates.Template do
   def apply(%Project{mix_project?: true} = project) do
     MixTemplate.apply(project)
 
+    ExUnit.apply(project)
+
     post_apply(project)
   end
 
   def apply(%Project{mix_project?: false} = project) do
     PhoenixTemplate.apply(project)
+
+    ExUnit.apply(project)
 
     post_apply(project)
   end

--- a/lib/nimble_template/templates/variants/mix/template.ex
+++ b/lib/nimble_template/templates/variants/mix/template.ex
@@ -8,6 +8,12 @@ defmodule NimbleTemplate.Templates.Mix.Template do
 
   def apply(%Project{} = project) do
     project
+    |> apply_default_mix_addons()
+    |> apply_optional_mix_addons()
+  end
+
+  defp apply_default_mix_addons(project) do
+    project
     |> Addons.ElixirVersion.apply()
     |> Addons.Readme.apply()
     |> Addons.TestEnv.apply()
@@ -15,7 +21,9 @@ defmodule NimbleTemplate.Templates.Mix.Template do
     |> Addons.Dialyxir.apply()
     |> Addons.ExCoveralls.apply()
     |> Addons.Faker.apply()
+  end
 
+  defp apply_optional_mix_addons(project) do
     if host_on_github?() do
       if generate_github_template?(),
         do: Addons.Github.apply(project, %{github_template: true})
@@ -38,8 +46,6 @@ defmodule NimbleTemplate.Templates.Mix.Template do
     end
 
     if install_addon_prompt?("Mimic"), do: Addons.Mimic.apply(project)
-
-    Addons.ExUnit.apply(project)
 
     project
   end

--- a/lib/nimble_template/templates/variants/phoenix/api/template.ex
+++ b/lib/nimble_template/templates/variants/phoenix/api/template.ex
@@ -5,6 +5,10 @@ defmodule NimbleTemplate.Templates.Phoenix.Api.Template do
   alias NimbleTemplate.Projects.Project
 
   def apply(%Project{} = project) do
+    apply_default_api_addons(project)
+  end
+
+  defp apply_default_api_addons(project) do
     project
     |> Api.Config.apply()
     |> Api.ParamsValidation.apply()

--- a/lib/nimble_template/templates/variants/phoenix/live/template.ex
+++ b/lib/nimble_template/templates/variants/phoenix/live/template.ex
@@ -5,8 +5,10 @@ defmodule NimbleTemplate.Templates.Phoenix.Live.Template do
   alias NimbleTemplate.Templates.Phoenix.Web.Template, as: WebTemplate
 
   def apply(%Project{} = project) do
-    WebTemplate.apply(project)
+    apply_web_addons(project)
+  end
 
-    project
+  defp apply_web_addons(project) do
+    WebTemplate.apply(project)
   end
 end

--- a/lib/nimble_template/templates/variants/phoenix/web/template.ex
+++ b/lib/nimble_template/templates/variants/phoenix/web/template.ex
@@ -8,6 +8,12 @@ defmodule NimbleTemplate.Templates.Phoenix.Web.Template do
 
   def apply(%Project{} = project) do
     project
+    |> apply_default_web_addons()
+    |> apply_optional_web_addons()
+  end
+
+  defp apply_default_web_addons(project) do
+    project
     |> Web.Assets.apply()
     |> Web.CoreJS.apply()
     |> Web.Prettier.apply()
@@ -15,7 +21,9 @@ defmodule NimbleTemplate.Templates.Phoenix.Web.Template do
     |> Web.Wallaby.apply()
     |> Web.EsLint.apply()
     |> Web.StyleLint.apply()
+  end
 
+  defp apply_optional_web_addons(project) do
     if install_addon_prompt?("SVG Sprite"), do: Web.SvgSprite.apply(project)
 
     project

--- a/test/nimble_template/addons/variants/docker_test.exs
+++ b/test/nimble_template/addons/variants/docker_test.exs
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.DockerTest do
+defmodule NimbleTemplate.Addons.Phoenix.DockerTest do
   use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
@@ -7,7 +7,7 @@ defmodule NimbleTemplate.Addons.DockerTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.Docker.apply(project)
+        PhoenixAddons.Docker.apply(project)
 
         assert_file("docker-compose.dev.yml", fn file ->
           assert file =~ """
@@ -32,7 +32,7 @@ defmodule NimbleTemplate.Addons.DockerTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.Docker.apply(project)
+        PhoenixAddons.Docker.apply(project)
 
         assert_file("docker-compose.yml")
       end)
@@ -43,7 +43,7 @@ defmodule NimbleTemplate.Addons.DockerTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.Docker.apply(project)
+        PhoenixAddons.Docker.apply(project)
 
         assert_file(".dockerignore")
       end)
@@ -54,7 +54,7 @@ defmodule NimbleTemplate.Addons.DockerTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.Docker.apply(project)
+        PhoenixAddons.Docker.apply(project)
 
         assert_file("Dockerfile", fn file ->
           assert file =~ """
@@ -89,7 +89,7 @@ defmodule NimbleTemplate.Addons.DockerTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.Docker.apply(project)
+        PhoenixAddons.Docker.apply(project)
 
         assert_file("bin/start.sh", fn file ->
           assert file =~ """
@@ -110,7 +110,7 @@ defmodule NimbleTemplate.Addons.DockerTest do
       project = %{project | api_project?: true, web_project?: false}
 
       in_test_project(test_project_path, fn ->
-        Addons.Docker.apply(project)
+        PhoenixAddons.Docker.apply(project)
 
         assert_file("Dockerfile", fn file ->
           refute file =~ """

--- a/test/nimble_template/addons/variants/ecto_data_migration_test.exs
+++ b/test/nimble_template/addons/variants/ecto_data_migration_test.exs
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.EctoDataMigrationTest do
+defmodule NimbleTemplate.Addons.Phoenix.EctoDataMigrationTest do
   use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
@@ -7,7 +7,7 @@ defmodule NimbleTemplate.Addons.EctoDataMigrationTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.EctoDataMigration.apply(project)
+        PhoenixAddons.EctoDataMigration.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -24,7 +24,7 @@ defmodule NimbleTemplate.Addons.EctoDataMigrationTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.EctoDataMigration.apply(project)
+        PhoenixAddons.EctoDataMigration.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -45,7 +45,7 @@ defmodule NimbleTemplate.Addons.EctoDataMigrationTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.EctoDataMigration.apply(project)
+        PhoenixAddons.EctoDataMigration.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -60,7 +60,7 @@ defmodule NimbleTemplate.Addons.EctoDataMigrationTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.EctoDataMigration.apply(project)
+        PhoenixAddons.EctoDataMigration.apply(project)
 
         assert_file("priv/repo/data_migrations/.keep")
       end)

--- a/test/nimble_template/addons/variants/ex_machina_test.exs
+++ b/test/nimble_template/addons/variants/ex_machina_test.exs
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.ExMachinaTest do
+defmodule NimbleTemplate.Addons.Phoenix.ExMachinaTest do
   use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
@@ -9,7 +9,7 @@ defmodule NimbleTemplate.Addons.ExMachinaTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.ExMachina.apply(project)
+        PhoenixAddons.ExMachina.apply(project)
 
         assert_file("test/support/factory.ex")
       end)
@@ -20,7 +20,7 @@ defmodule NimbleTemplate.Addons.ExMachinaTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.ExMachina.apply(project)
+        PhoenixAddons.ExMachina.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -37,7 +37,7 @@ defmodule NimbleTemplate.Addons.ExMachinaTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.ExMachina.apply(project)
+        PhoenixAddons.ExMachina.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -49,7 +49,7 @@ defmodule NimbleTemplate.Addons.ExMachinaTest do
 
     test "updates test/test_helper.exs", %{project: project, test_project_path: test_project_path} do
       in_test_project(test_project_path, fn ->
-        Addons.ExMachina.apply(project)
+        PhoenixAddons.ExMachina.apply(project)
 
         assert_file("test/test_helper.exs", fn file ->
           assert file =~ """
@@ -63,7 +63,7 @@ defmodule NimbleTemplate.Addons.ExMachinaTest do
 
     test "adds Factory module", %{project: project, test_project_path: test_project_path} do
       in_test_project(test_project_path, fn ->
-        Addons.ExMachina.apply(project)
+        PhoenixAddons.ExMachina.apply(project)
 
         assert_file("test/support/data_case.ex", fn file ->
           assert file =~ "import NimbleTemplate.Factory"

--- a/test/nimble_template/addons/variants/ex_vcr_test.exs
+++ b/test/nimble_template/addons/variants/ex_vcr_test.exs
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.ExVCRTest do
+defmodule NimbleTemplate.Addons.Phoenix.ExVCRTest do
   use NimbleTemplate.AddonCase
 
   describe "#apply/2" do
@@ -9,7 +9,7 @@ defmodule NimbleTemplate.Addons.ExVCRTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.ExVCR.apply(project)
+        PhoenixAddons.ExVCR.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ "{:exvcr, \"~> 0.12.2\", [only: :test]}"
@@ -22,7 +22,7 @@ defmodule NimbleTemplate.Addons.ExVCRTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.ExVCR.apply(project)
+        PhoenixAddons.ExVCR.apply(project)
 
         assert_file("config/test.exs", fn file ->
           assert file =~ """
@@ -37,7 +37,7 @@ defmodule NimbleTemplate.Addons.ExVCRTest do
 
     test "updates test cases", %{project: project, test_project_path: test_project_path} do
       in_test_project(test_project_path, fn ->
-        Addons.ExVCR.apply(project)
+        PhoenixAddons.ExVCR.apply(project)
 
         assert_file("test/support/data_case.ex", fn file ->
           assert file =~ "use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney"
@@ -54,7 +54,7 @@ defmodule NimbleTemplate.Addons.ExVCRTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.ExVCR.apply(project)
+        PhoenixAddons.ExVCR.apply(project)
 
         assert(File.exists?("test/support/fixtures/vcr_cassettes/.keep")) == true
       end)

--- a/test/nimble_template/addons/variants/makefile_test.exs
+++ b/test/nimble_template/addons/variants/makefile_test.exs
@@ -1,10 +1,10 @@
-defmodule NimbleTemplate.Addons.MakefileTest do
+defmodule NimbleTemplate.Addons.Phoenix.MakefileTest do
   use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
     test "copies the Makefile", %{project: project, test_project_path: test_project_path} do
       in_test_project(test_project_path, fn ->
-        Addons.Makefile.apply(project)
+        PhoenixAddons.Makefile.apply(project)
 
         assert_file("Makefile")
       end)

--- a/test/nimble_template/addons/variants/mix_release_test.exs
+++ b/test/nimble_template/addons/variants/mix_release_test.exs
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.MixReleaseTest do
+defmodule NimbleTemplate.Addons.Phoenix.MixReleaseTest do
   use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
@@ -7,7 +7,7 @@ defmodule NimbleTemplate.Addons.MixReleaseTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.MixRelease.apply(project)
+        PhoenixAddons.MixRelease.apply(project)
 
         assert_file("config/prod.exs", fn file ->
           refute file =~ """
@@ -24,7 +24,7 @@ defmodule NimbleTemplate.Addons.MixReleaseTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.MixRelease.apply(project)
+        PhoenixAddons.MixRelease.apply(project)
 
         refute_file("config/prod.secret.exs")
       end)
@@ -35,7 +35,7 @@ defmodule NimbleTemplate.Addons.MixReleaseTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.MixRelease.apply(project)
+        PhoenixAddons.MixRelease.apply(project)
 
         assert_file("config/runtime.exs", fn file ->
           assert file =~ """
@@ -52,7 +52,7 @@ defmodule NimbleTemplate.Addons.MixReleaseTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.MixRelease.apply(project)
+        PhoenixAddons.MixRelease.apply(project)
 
         assert_file("lib/nimble_template/release_tasks.ex", fn file ->
           assert file =~ """

--- a/test/nimble_template/addons/variants/oban_test.exs
+++ b/test/nimble_template/addons/variants/oban_test.exs
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.ObanTest do
+defmodule NimbleTemplate.Addons.Phoenix.ObanTest do
   use NimbleTemplate.AddonCase, async: false
   use Mimic
 
@@ -10,7 +10,7 @@ defmodule NimbleTemplate.Addons.ObanTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.Oban.apply(project)
+        PhoenixAddons.Oban.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -29,7 +29,7 @@ defmodule NimbleTemplate.Addons.ObanTest do
       in_test_project(test_project_path, fn ->
         expect(Calendar, :strftime, fn _datetime, _format -> "20201120074154" end)
 
-        Addons.Oban.apply(project)
+        PhoenixAddons.Oban.apply(project)
 
         assert_file("priv/repo/migrations/20201120074154_add_oban_jobs_table.exs", fn file ->
           assert file =~ """
@@ -56,7 +56,7 @@ defmodule NimbleTemplate.Addons.ObanTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.Oban.apply(project)
+        PhoenixAddons.Oban.apply(project)
 
         assert_file("lib/nimble_template/application.ex", fn file ->
           assert file =~ """
@@ -78,7 +78,7 @@ defmodule NimbleTemplate.Addons.ObanTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.Oban.apply(project)
+        PhoenixAddons.Oban.apply(project)
 
         assert_file("config/config.exs", fn file ->
           assert file =~ """
@@ -96,7 +96,7 @@ defmodule NimbleTemplate.Addons.ObanTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.Oban.apply(project)
+        PhoenixAddons.Oban.apply(project)
 
         assert_file("config/test.exs", fn file ->
           assert file =~ """
@@ -111,7 +111,7 @@ defmodule NimbleTemplate.Addons.ObanTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.Oban.apply(project)
+        PhoenixAddons.Oban.apply(project)
 
         assert(File.exists?("lib/nimble_template_worker/.keep")) == true
       end)

--- a/test/nimble_template/addons/variants/phoenix/api/config_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/api/config_test.exs
@@ -7,7 +7,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Api.ConfigTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsApi.Config.apply(project)
+        ApiAddons.Config.apply(project)
 
         assert_file("config/prod.exs", fn file ->
           refute file =~ "cache_static_manifest: \"priv/static/cache_manifest.json\""

--- a/test/nimble_template/addons/variants/phoenix/api/params_validation_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/api/params_validation_test.exs
@@ -7,7 +7,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Api.ParamsValidationTest do
       test_project_path: project_path
     } do
       in_test_project(project_path, fn ->
-        AddonsApi.ParamsValidation.apply(project)
+        ApiAddons.ParamsValidation.apply(project)
 
         assert_file("lib/nimble_template_web/params/params.ex")
         assert_file("lib/nimble_template_web/params/params_validator.ex")

--- a/test/nimble_template/addons/variants/phoenix/web/assets_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/assets_test.exs
@@ -4,7 +4,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.AssetsTest do
   describe "#apply/2" do
     test "adds assets.compile alias", %{project: project, test_project_path: test_project_path} do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Assets.apply(project)
+        WebAddons.Assets.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -21,7 +21,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.AssetsTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Assets.apply(project)
+        WebAddons.Assets.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -38,7 +38,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.AssetsTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Assets.apply(project)
+        WebAddons.Assets.apply(project)
 
         assert_file("assets/package.json", fn file ->
           assert file =~ """
@@ -54,7 +54,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.AssetsTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Assets.apply(project)
+        WebAddons.Assets.apply(project)
 
         assert_file("lib/nimble_template_web/endpoint.ex", fn file ->
           assert file =~ "gzip: true,"

--- a/test/nimble_template/addons/variants/phoenix/web/core_js_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/core_js_test.exs
@@ -7,7 +7,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.CoreJSTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.CoreJS.apply(project)
+        WebAddons.CoreJS.apply(project)
 
         assert_file("assets/package.json", fn file ->
           assert file =~ """
@@ -19,7 +19,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.CoreJSTest do
 
     test "imports core-js into app.js", %{project: project, test_project_path: test_project_path} do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.CoreJS.apply(project)
+        WebAddons.CoreJS.apply(project)
 
         assert_file("assets/js/app.js", fn file ->
           assert file =~ """
@@ -40,7 +40,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.CoreJSTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.CoreJS.apply(project)
+        WebAddons.CoreJS.apply(project)
 
         assert_file("assets/package.json", fn file ->
           assert file =~ """

--- a/test/nimble_template/addons/variants/phoenix/web/es_lint_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/es_lint_test.exs
@@ -9,7 +9,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.EsLintTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.EsLint.apply(project)
+        WebAddons.EsLint.apply(project)
 
         assert_file("assets/package.json", fn file ->
           assert file =~ """
@@ -26,7 +26,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.EsLintTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.EsLint.apply(project)
+        WebAddons.EsLint.apply(project)
 
         assert_file("assets/package.json", fn file ->
           assert file =~ """
@@ -42,7 +42,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.EsLintTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.EsLint.apply(project)
+        WebAddons.EsLint.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -58,7 +58,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.EsLintTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.EsLint.apply(project)
+        WebAddons.EsLint.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -74,7 +74,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.EsLintTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.EsLint.apply(project)
+        WebAddons.EsLint.apply(project)
 
         assert_file("assets/.eslintrc.json")
       end)
@@ -90,7 +90,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.EsLintTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.EsLint.apply(project)
+        WebAddons.EsLint.apply(project)
 
         assert_file("assets/js/app.js", fn file ->
           assert file =~

--- a/test/nimble_template/addons/variants/phoenix/web/prettier_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/prettier_test.exs
@@ -9,7 +9,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.PrettierTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Prettier.apply(project)
+        WebAddons.Prettier.apply(project)
 
         assert_file("assets/package.json", fn file ->
           assert file =~ """
@@ -25,7 +25,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.PrettierTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Prettier.apply(project)
+        WebAddons.Prettier.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -43,7 +43,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.PrettierTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Prettier.apply(project)
+        WebAddons.Prettier.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -59,7 +59,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.PrettierTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Prettier.apply(project)
+        WebAddons.Prettier.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -75,7 +75,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.PrettierTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Prettier.apply(project)
+        WebAddons.Prettier.apply(project)
 
         assert_file(".prettierignore")
         assert_file(".prettierrc.yaml")

--- a/test/nimble_template/addons/variants/phoenix/web/sobelow_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/sobelow_test.exs
@@ -10,7 +10,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.SobelowTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Sobelow.apply(project)
+        WebAddons.Sobelow.apply(project)
 
         assert_file(".sobelow-conf")
       end)
@@ -21,7 +21,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.SobelowTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Sobelow.apply(project)
+        WebAddons.Sobelow.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -35,7 +35,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.SobelowTest do
 
     test "adds sobelow codebase alias", %{project: project, test_project_path: test_project_path} do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Sobelow.apply(project)
+        WebAddons.Sobelow.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """

--- a/test/nimble_template/addons/variants/phoenix/web/style_lint_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/style_lint_test.exs
@@ -12,7 +12,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.StyleLintTest do
            test_project_path: test_project_path
          } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.StyleLint.apply(project)
+        WebAddons.StyleLint.apply(project)
 
         assert_file("assets/package.json", fn file ->
           assert file =~ """
@@ -29,7 +29,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.StyleLintTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.StyleLint.apply(project)
+        WebAddons.StyleLint.apply(project)
 
         assert_file("assets/package.json", fn file ->
           assert file =~ """
@@ -45,7 +45,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.StyleLintTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.StyleLint.apply(project)
+        WebAddons.StyleLint.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -61,7 +61,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.StyleLintTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.StyleLint.apply(project)
+        WebAddons.StyleLint.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -77,7 +77,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.StyleLintTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.StyleLint.apply(project)
+        WebAddons.StyleLint.apply(project)
 
         assert_file("assets/.stylelintrc.json")
       end)

--- a/test/nimble_template/addons/variants/phoenix/web/svg_sprite_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/svg_sprite_test.exs
@@ -7,7 +7,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.SvgSpriteTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.SvgSprite.apply(project)
+        WebAddons.SvgSprite.apply(project)
 
         assert_file("assets/package.json", fn file ->
           assert file =~ """
@@ -22,7 +22,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.SvgSpriteTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.SvgSprite.apply(project)
+        WebAddons.SvgSprite.apply(project)
 
         assert_file("assets/package.json", fn file ->
           assert file =~ """
@@ -37,7 +37,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.SvgSpriteTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.SvgSprite.apply(project)
+        WebAddons.SvgSprite.apply(project)
 
         assert_file("lib/nimble_template_web.ex", fn file ->
           assert file =~ """
@@ -52,7 +52,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.SvgSpriteTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.SvgSprite.apply(project)
+        WebAddons.SvgSprite.apply(project)
 
         assert_file("lib/nimble_template_web/helpers/icon_helper.ex")
       end)
@@ -63,7 +63,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.SvgSpriteTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.SvgSprite.apply(project)
+        WebAddons.SvgSprite.apply(project)
 
         assert_file("test/nimble_template_web/helpers/icon_helper_test.exs")
       end)
@@ -74,7 +74,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.SvgSpriteTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.SvgSprite.apply(project)
+        WebAddons.SvgSprite.apply(project)
 
         refute_file(".github/wiki/Icon-Sprite.md")
       end)
@@ -85,7 +85,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.SvgSpriteTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.SvgSprite.apply(project)
+        WebAddons.SvgSprite.apply(project)
 
         refute_file(".github/wiki/_Sidebar.md")
       end)
@@ -100,7 +100,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.SvgSpriteTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.SvgSprite.apply(project)
+        WebAddons.SvgSprite.apply(project)
 
         assert_file(".github/wiki/Icon-Sprite.md")
       end)
@@ -111,7 +111,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.SvgSpriteTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.SvgSprite.apply(project)
+        WebAddons.SvgSprite.apply(project)
 
         assert_file(".github/wiki/_Sidebar.md", fn file ->
           assert file =~ """

--- a/test/nimble_template/addons/variants/phoenix/web/wallaby_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/wallaby_test.exs
@@ -9,7 +9,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.WallabyTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Wallaby.apply(project)
+        WebAddons.Wallaby.apply(project)
 
         assert_file("test/support/feature_case.ex", fn file ->
           assert file =~ """
@@ -36,7 +36,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.WallabyTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Wallaby.apply(project)
+        WebAddons.Wallaby.apply(project)
 
         assert_file("test/nimble_template_web/features/home_page/view_home_page_test.exs")
       end)
@@ -47,7 +47,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.WallabyTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Wallaby.apply(project)
+        WebAddons.Wallaby.apply(project)
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
@@ -64,7 +64,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.WallabyTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Wallaby.apply(project)
+        WebAddons.Wallaby.apply(project)
 
         assert_file("test/test_helper.exs", fn file ->
           assert file =~ """
@@ -84,7 +84,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.WallabyTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Wallaby.apply(project)
+        WebAddons.Wallaby.apply(project)
 
         assert_file("lib/nimble_template_web/endpoint.ex", fn file ->
           assert file =~ """
@@ -103,7 +103,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.WallabyTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Wallaby.apply(project)
+        WebAddons.Wallaby.apply(project)
 
         assert_file("config/test.exs", fn file ->
           assert file =~ """
@@ -128,7 +128,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.WallabyTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        AddonsWeb.Wallaby.apply(project)
+        WebAddons.Wallaby.apply(project)
 
         assert_file(".gitignore", fn file ->
           assert file =~ "**/tmp/"

--- a/test/nimble_template/helpers/dependency_test.exs
+++ b/test/nimble_template/helpers/dependency_test.exs
@@ -2,6 +2,7 @@ defmodule NimbleTemplate.DependencyTest do
   use NimbleTemplate.AddonCase, async: false
 
   alias NimbleTemplate.{Addons, DependencyHelper}
+  alias NimbleTemplate.Addons.Phoenix, as: PhoenixAddons
 
   describe "order_dependencies!/0" do
     @describetag mock_latest_package_versions: [{:exvcr, "0.12.2"}, {:mimic, "1.3.1"}]
@@ -11,7 +12,7 @@ defmodule NimbleTemplate.DependencyTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.ExVCR.apply(project)
+        PhoenixAddons.ExVCR.apply(project)
         Addons.Mimic.apply(project)
 
         # Unordered mix dependencies

--- a/test/support/addon_case.ex
+++ b/test/support/addon_case.ex
@@ -4,16 +4,17 @@ defmodule NimbleTemplate.AddonCase do
   use Mimic
 
   alias NimbleTemplate.Addons
-  alias NimbleTemplate.Addons.Phoenix.Api, as: AddonsApi
-  alias NimbleTemplate.Addons.Phoenix.Web, as: AddonsWeb
+  alias NimbleTemplate.Addons.Phoenix.Api, as: ApiAddons
+  alias NimbleTemplate.Addons.Phoenix.Web, as: WebAddons
   alias NimbleTemplate.Hex.Package
   alias NimbleTemplate.Projects.Project
 
   using do
     quote do
       alias NimbleTemplate.Addons
-      alias NimbleTemplate.Addons.Phoenix.Api, as: AddonsApi
-      alias NimbleTemplate.Addons.Phoenix.Web, as: AddonsWeb
+      alias NimbleTemplate.Addons.Phoenix, as: PhoenixAddons
+      alias NimbleTemplate.Addons.Phoenix.Api, as: ApiAddons
+      alias NimbleTemplate.Addons.Phoenix.Web, as: WebAddons
 
       # ATTENTION: File.cd! doesn't support `async: true`, the test will fail randomly in async mode
       # https://elixirforum.com/t/randomly-getting-compilationerror-on-tests/17298/3


### PR DESCRIPTION
## What happened

Refactor the Addon modules as some modules if applied only to the Phoenix variant, some applied for both Phoenix and Mix.

## Insight

1. Separate the addon
- Common addon (Mix + Phoenix)
- Common Phoenix addon (Web + Live + API)
- Specific Mix addons
- Specific Web addons
- Specific Live addons
- Specific API addons

![image](https://user-images.githubusercontent.com/11751745/148331788-1aa87ce9-d644-4e9e-bee1-22a8fcf8df2c.png)

2. Some other minor refactor to make the codebase clearer 

## Proof Of Work

The test is passed
