### PR TITLE
Improve the Test workflow with Github action Cache

### DIFF
--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -51,6 +51,49 @@ jobs:
 
       - name: Run codebase check
         run: mix codebase
+        
+  unit_test:
+    name: Unit test
+    
+    needs: lint_codebase
+    
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Elixir ${{ env.ELIXIR_VERSION }} and OTP ${{ env.OTP_VERSION }}
+        uses: erlef/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - name: Install Dependencies
+        run: mix deps.get
+
+      - name: Compile dependencies
+        run: mix compile
+
+      - name: Install Phoenix ${{ env.PHOENIX_VERSION }}
+        run: make install_phoenix PHOENIX_VERSION=${{ env.PHOENIX_VERSION }}
 
       - name: Run Tests
         run: mix test

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -9,11 +9,56 @@ env:
   MIX_ENV: test
 
 jobs:
-  unit_test:
-    name: Run unit test
+  install_and_compile_dependencies:
+    name: Install and Compile Dependencies
     runs-on: ubuntu-latest
 
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Elixir ${{ env.ELIXIR_VERSION }} and OTP ${{ env.OTP_VERSION }}
+        uses: erlef/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - name: Install Dependencies
+        run: mix deps.get
+
+      - name: Compile dependencies
+        run: mix compile
+
+  lint_codebase:
+    name: Linting
+    
+    needs: install_and_compile_dependencies
+    
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
@@ -55,6 +100,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout repository
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -14,11 +14,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
@@ -60,11 +55,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout repository
         uses: actions/checkout@v2
         with:

--- a/priv/templates/nimble_template/.github/workflows/test.yml.eex
+++ b/priv/templates/nimble_template/.github/workflows/test.yml.eex
@@ -12,6 +12,7 @@ env:
 jobs:
   install_and_compile_dependencies:
     name: Install and Compile Dependencies
+
     runs-on: ubuntu-latest
 
     steps:
@@ -46,7 +47,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-
       <%= if web_project? do %>
-      - name: Cache Node npm
+      - name: Cache Node modules
         uses: actions/cache@v2
         with:
           path: assets/node_modules
@@ -54,14 +55,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       <% end %>
-      - name: Install Dependencies
+      - name: Install Elixir dependencies
         run: mix deps.get
 
       - name: Compile dependencies
         run: mix compile
 
       <%= if web_project? do %>
-      - name: Install node module
+      - name: Install Node dependencies
         run: npm --prefix assets install
 
       - name: Compile assets
@@ -114,7 +115,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-
       <%= if web_project? do %>
-      - name: Cache Node npm
+      - name: Cache Node modules
         uses: actions/cache@v2
         with:
           path: assets/node_modules
@@ -122,14 +123,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       <% end %>
-      - name: Install Dependencies
+      - name: Install Elixir dependencies
         run: mix deps.get
 
       - name: Compile dependencies
         run: mix compile --warnings-as-errors --all-warnings
 
       <%= if web_project? do %>
-      - name: Install node module
+      - name: Install Node dependencies
         run: npm --prefix assets install
 
       - name: Compile assets
@@ -193,7 +194,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-
       <%= if web_project? do %>
-      - name: Cache Node npm
+      - name: Cache Node modules
         uses: actions/cache@v2
         with:
           path: assets/node_modules
@@ -201,14 +202,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       <% end %>
-      - name: Install Dependencies
+      - name: Install Elixir dependencies
         run: mix deps.get
 
       - name: Compile dependencies
         run: mix compile
 
       <%= if web_project? do %>
-      - name: Install node module
+      - name: Install Node dependencies
         run: npm --prefix assets install
 
       - name: Compile assets
@@ -269,7 +270,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-
       <%= if web_project? do %>
-      - name: Cache Node npm
+      - name: Cache Node modules
         uses: actions/cache@v2
         with:
           path: assets/node_modules
@@ -277,14 +278,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       <% end %>
-      - name: Install Dependencies
+      - name: Install Elixir dependencies
         run: mix deps.get
 
       - name: Compile dependencies
         run: mix compile
 
       <%= if web_project? do %>
-      - name: Install node module
+      - name: Install Node dependencies
         run: npm --prefix assets install
 
       - name: Compile assets
@@ -356,7 +357,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-
 
-      - name: Cache Node npm
+      - name: Cache Node modules
         uses: actions/cache@v2
         with:
           path: assets/node_modules
@@ -364,13 +365,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Install Dependencies
+      - name: Install Elixir dependencies
         run: mix deps.get
 
       - name: Compile dependencies
         run: mix compile
 
-      - name: Install node module
+      - name: Install Node dependencies
         run: npm --prefix assets install
 
       - name: Compile assets

--- a/priv/templates/nimble_template/.github/workflows/test.yml.eex
+++ b/priv/templates/nimble_template/.github/workflows/test.yml.eex
@@ -10,8 +10,69 @@ env:
   DB_HOST: localhost
 
 jobs:
-  test:
-    name: Test
+  install_and_compile_dependencies:
+    name: Install and Compile Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Elixir
+        uses: erlef/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+      <%= if web_project? do %>
+      - name: Set up Node
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      <% end %>
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+      <%= if web_project? do %>
+      - name: Cache Node npm
+        uses: actions/cache@v2
+        with:
+          path: assets/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      <% end %>
+      - name: Install Dependencies
+        run: mix deps.get
+
+      - name: Compile dependencies
+        run: mix compile
+
+      <%= if web_project? do %>
+      - name: Install node module
+        run: npm --prefix assets install
+
+      - name: Compile assets
+        run: npm run --prefix assets build:dev
+      <% end %>
+
+  lint_codebase:
+    name: Linting
+    
+    needs: install_and_compile_dependencies
+    
     runs-on: ubuntu-latest
 
     services:
@@ -27,11 +88,6 @@ jobs:
           --health-retries 5
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
@@ -87,9 +143,161 @@ jobs:
 
       - name: Run codebase check
         run: mix codebase
+    
+  seed_data:
+    name: Test seed data
+    
+    needs: lint_codebase
+    
+    runs-on: ubuntu-latest
+
+    services:
+      db:
+        image: postgres:12.3
+        ports: ['5432:5432']
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    
+    env:
+      MIX_ENV: dev
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Elixir
+        uses: erlef/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+      <%= if web_project? do %>
+      - name: Set up Node
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      <% end %>
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+      <%= if web_project? do %>
+      - name: Cache Node npm
+        uses: actions/cache@v2
+        with:
+          path: assets/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      <% end %>
+      - name: Install Dependencies
+        run: mix deps.get
+
+      - name: Compile dependencies
+        run: mix compile
+
+      <%= if web_project? do %>
+      - name: Install node module
+        run: npm --prefix assets install
+
+      - name: Compile assets
+        run: npm run --prefix assets build:dev
+      <% end %>
+      - name: Create database
+        run: mix ecto.create
+
+      - name: Migrate database
+        run: mix ecto.migrate
+
+      - name: Seed data
+        run: mix run priv/repo/seeds.exs
+      
+  unit_test:
+    name: Unit test
+    
+    needs: lint_codebase
+    
+    runs-on: ubuntu-latest
+
+    services:
+      db:
+        image: postgres:12.3
+        ports: ['5432:5432']
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Elixir
+        uses: erlef/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+      <%= if web_project? do %>
+      - name: Set up Node
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      <% end %>
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+      <%= if web_project? do %>
+      - name: Cache Node npm
+        uses: actions/cache@v2
+        with:
+          path: assets/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      <% end %>
+      - name: Install Dependencies
+        run: mix deps.get
+
+      - name: Compile dependencies
+        run: mix compile
+
+      <%= if web_project? do %>
+      - name: Install node module
+        run: npm --prefix assets install
+
+      - name: Compile assets
+        run: npm run --prefix assets build:dev
+      <% end %>
+      - name: Create database
+        run: mix ecto.create
+
+      - name: Migrate database
+        run: mix ecto.migrate
 
       - name: Run Tests
-        run: mix coverage
+        run: mix coverage --exclude feature_test
 
       - name: Upload Code Coverage Artifact
         uses: actions/upload-artifact@v2
@@ -97,12 +305,92 @@ jobs:
         with:
           name: code_coverage
           path: cover/
+<%= if web_project? do %>
+  feature_test:
+    name: Feature test
+    
+    needs: lint_codebase
+    
+    runs-on: ubuntu-latest
 
-      <%= if web_project? do %>
+    services:
+      db:
+        image: postgres:12.3
+        ports: ['5432:5432']
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    strategy:
+      matrix:
+        mix_test_partition: [1, 2, 3, 4]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Elixir
+        uses: erlef/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+      
+      - name: Set up Node
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - name: Cache Node npm
+        uses: actions/cache@v2
+        with:
+          path: assets/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Dependencies
+        run: mix deps.get
+
+      - name: Compile dependencies
+        run: mix compile
+
+      - name: Install node module
+        run: npm --prefix assets install
+
+      - name: Compile assets
+        run: npm run --prefix assets build:dev
+        
+      - name: Create database
+        run: mix ecto.create
+
+      - name: Migrate database
+        run: mix ecto.migrate
+
+      - name: Run Tests
+        run: mix test --only feature_test --partitions 4
+        env:
+          MIX_TEST_PARTITION: ${{ matrix.mix_test_partition }}
+
       - name: Upload Wallaby Screenshots Artifact
         uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
           name: wallaby_screenshots
           path: tmp/wallaby_screenshots/
-      <% end %>
+<% end %>

--- a/priv/templates/nimble_template/.github/workflows/test.yml.eex
+++ b/priv/templates/nimble_template/.github/workflows/test.yml.eex
@@ -145,8 +145,8 @@ jobs:
       - name: Run codebase check
         run: mix codebase
     
-  seed_data:
-    name: Test seed data
+  test_database_seeds:
+    name: Test database seeds
     
     needs: lint_codebase
     
@@ -221,7 +221,7 @@ jobs:
       - name: Migrate database
         run: mix ecto.migrate
 
-      - name: Seed data
+      - name: Seed database
         run: mix run priv/repo/seeds.exs
       
   unit_test:

--- a/priv/templates/nimble_template/.github/workflows/test.yml.mix.eex
+++ b/priv/templates/nimble_template/.github/workflows/test.yml.mix.eex
@@ -8,8 +8,8 @@ env:
   MIX_ENV: test
 
 jobs:
-  test:
-    name: Test
+  install_and_compile_dependencies:
+    name: Install and Compile Dependencies
     runs-on: ubuntu-latest
 
     steps:
@@ -43,10 +43,80 @@ jobs:
         run: mix deps.get
 
       - name: Compile dependencies
+        run: mix compile
+          
+  lint_codebase:
+    name: Linting
+    
+    needs: install_and_compile_dependencies
+    
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Elixir
+        uses: erlef/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Compile dependencies
         run: mix compile --warnings-as-errors --all-warnings
 
       - name: Run codebase check
         run: mix codebase
+          
+  test:
+    name: Unit Test
+    
+    needs: lint_codebase
+    
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Elixir
+        uses: erlef/setup-elixir@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Cache Elixir build
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Compile dependencies
+        run: mix compile
 
       - name: Run Tests
         run: mix coverage

--- a/priv/templates/nimble_template/.github/workflows/test.yml.mix.eex
+++ b/priv/templates/nimble_template/.github/workflows/test.yml.mix.eex
@@ -10,6 +10,7 @@ env:
 jobs:
   install_and_compile_dependencies:
     name: Install and Compile Dependencies
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What happened

Separate the Test workflow into different steps to make the Github Cache working effective 

## Insight

For the test workflow, it contains multiple steps

- install_and_compile_dependencies
- lint_codebase
- unit_test

We need to separate to different steps to have the benefit from the Github cache action, because the Github cache action doesn't cache if the `mix codebase is failed`, so on the next time, it won't have the cache.

![image](https://user-images.githubusercontent.com/11751745/150271437-bfa60f04-7592-4a16-b14c-789f4bc1a73f.png)

With the install_and_compile_dependencies it just installs the dependency and caches it, so on the next step (and next time), it will use the cache.

### Github Addon

Refactor the Github Addon

1/ Mix project: Separate into 3 steps

2/ Phoenix project: Separate into 5 steps, also introduce the new `test seed data` on each PR, we have that in one of our client projects.

<img width="462" alt="image" src="https://user-images.githubusercontent.com/11751745/150273040-667aa1dc-a7bf-4e66-9801-c654146eef2e.png">

Allow the feature test using partitions mode.

## Proof Of Work

The test is passed.

<img width="755" alt="image" src="https://user-images.githubusercontent.com/11751745/150271702-b4b7c93f-c3da-47a2-a161-b3673ebedab6.png">
