### PR TITLE
Change the Github reusable to relative path.

### DIFF
--- a/.github/workflows/apply_api_variant.yml
+++ b/.github/workflows/apply_api_variant.yml
@@ -5,28 +5,28 @@ on: push
 jobs:
   standard_api_project:
     name: Test on a Standard API project
-    uses: nimblehq/elixir-templates/.github/workflows/reusable_phoenix_project.yml@composite_2.0
+    uses: ./.github/workflows/reusable_phoenix_project.yml
     with:
       new_project_options: "--no-html --no-webpack"
       variant: "api"
 
   non-standard_api_project:
     name: Test on a Non-Standard API project
-    uses: nimblehq/elixir-templates/.github/workflows/reusable_phoenix_project.yml@composite_2.0
+    uses: ./.github/workflows/reusable_phoenix_project.yml
     with:
       new_project_options: "--no-html --no-webpack --module=SampleCustomModule --app=sample_custom_app"
       variant: "api"
 
   standard_web_project:
     name: Test on a Standard Web project
-    uses: nimblehq/elixir-templates/.github/workflows/reusable_phoenix_project.yml@composite_2.0
+    uses: ./.github/workflows/reusable_phoenix_project.yml
     with:
       new_project_options: ""
       variant: "api"
 
   non-standard_web_project:
     name: Test on a Non-Standard Web project
-    uses: nimblehq/elixir-templates/.github/workflows/reusable_phoenix_project.yml@composite_2.0
+    uses: ./.github/workflows/reusable_phoenix_project.yml
     with:
       new_project_options: "--module=SampleCustomModule --app=sample_custom_app"
       variant: "api"

--- a/.github/workflows/apply_live_variant.yml
+++ b/.github/workflows/apply_live_variant.yml
@@ -5,14 +5,14 @@ on: push
 jobs:
   standard_project:
     name: Test on a Standard Live project
-    uses: nimblehq/elixir-templates/.github/workflows/reusable_phoenix_project.yml@composite_2.0
+    uses: ./.github/workflows/reusable_phoenix_project.yml
     with:
       new_project_options: "--live"
       variant: "live"
 
   non-standard_project:
     name: Test on a Non-Standard Live project
-    uses: nimblehq/elixir-templates/.github/workflows/reusable_phoenix_project.yml@composite_2.0
+    uses: ./.github/workflows/reusable_phoenix_project.yml
     with:
       new_project_options: "--live --module=SampleCustomModule --app=sample_custom_app"
       variant: "live"

--- a/.github/workflows/apply_mix_variant.yml
+++ b/.github/workflows/apply_mix_variant.yml
@@ -5,24 +5,24 @@ on: push
 jobs:
   standard_mix_project:
     name: Test on a Standard Mix project
-    uses: nimblehq/elixir-templates/.github/workflows/reusable_mix_project.yml@composite_2.0
+    uses: ./.github/workflows/reusable_mix_project.yml
     with:
       new_project_options: ""
 
   non-standard_mix_project:
     name: Test on a Non-Standard Mix project
-    uses: nimblehq/elixir-templates/.github/workflows/reusable_mix_project.yml@composite_2.0
+    uses: ./.github/workflows/reusable_mix_project.yml
     with:
       new_project_options: "--module=SampleCustomModule --app=sample_custom_app"
       
   standard_mix_supervision_project:
     name: Test on a Standard Supervision Mix project
-    uses: nimblehq/elixir-templates/.github/workflows/reusable_mix_project.yml@composite_2.0
+    uses: ./.github/workflows/reusable_mix_project.yml
     with:
       new_project_options: "--sup"
 
   non-standard_mix_supervision_project:
     name: Test on a Non-Standard Supervision Mix  project
-    uses: nimblehq/elixir-templates/.github/workflows/reusable_mix_project.yml@composite_2.0
+    uses: ./.github/workflows/reusable_mix_project.yml
     with:
       new_project_options: "--sup --module=SampleCustomModule --app=sample_custom_app"

--- a/.github/workflows/apply_web_variant.yml
+++ b/.github/workflows/apply_web_variant.yml
@@ -5,14 +5,14 @@ on: push
 jobs:
   standard_project:
     name: Test on a Standard Web project
-    uses: nimblehq/elixir-templates/.github/workflows/reusable_phoenix_project.yml@composite_2.0
+    uses: ./.github/workflows/reusable_phoenix_project.yml
     with:
       new_project_options: ""
       variant: "web"
 
   non-standard_project:
     name: Test on a Non-Standard Web project
-    uses: nimblehq/elixir-templates/.github/workflows/reusable_phoenix_project.yml@composite_2.0
+    uses: ./.github/workflows/reusable_phoenix_project.yml
     with:
       new_project_options: "--module=SampleCustomModule --app=sample_custom_app"
       variant: "web"


### PR DESCRIPTION
https://github.com/nimblehq/elixir-templates/pull/162#discussion_r804546686

## What happened

Change the reusable workflow to a relative path followed by the suggestion from Long on https://github.com/nimblehq/elixir-templates/pull/162#discussion_r804546686

## Insight

https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow

With the relative path, we no need to release any tag for the reusable workflow like before, for now, it will always refer to the relative path on the same branch 😍 much much easier to understand and control when we need to adjust the `reusable workflow`.

## Proof Of Work

The test is passed.
