### PR TITLE
Bump version to 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Step 2: Add `nimble_template` dependency to `mix.exs`:
 ```elixir
 def deps do
   [
-    {:nimble_template, "~> 3.0", only: :dev, runtime: false},
+    {:nimble_template, "~> 4.0", only: :dev, runtime: false},
     # other dependencies ...
   ]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule NimbleTemplate.MixProject do
   def project do
     [
       app: :nimble_template,
-      version: "3.0.0",
+      version: "4.0.0",
       description: "Phoenix/Mix template for projects at [Nimble](https://nimblehq.co/).",
       elixir: "~> 1.12.2",
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
## What happened

Bump the Mix version to 4.0.0

## Insight

Bump the Mix version to 4.0.0 before making the release PR and publish to [Hex.pm](https://hex.pm/packages/nimble_template).

The reason why we decide to make this to be a new major release because.

- We have many refactor in the codebase structure in this release.
  - https://github.com/nimblehq/elixir-templates/pull/152
  - https://github.com/nimblehq/elixir-templates/pull/153
  - https://github.com/nimblehq/elixir-templates/pull/156
  - https://github.com/nimblehq/elixir-templates/pull/162
  - https://github.com/nimblehq/elixir-templates/pull/163
- We support Phoenix.1.6 which introduce the new EsBuild and DartSass tools
- And many features...

## Proof Of Work

The test is passed
