### PR TITLE
Reduce the partition to 1 as at beginning we have only 1 feature test

### DIFF
--- a/priv/templates/nimble_template/.github/workflows/test.yml.eex
+++ b/priv/templates/nimble_template/.github/workflows/test.yml.eex
@@ -320,10 +320,14 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
+    
+    # To have parallel feature test jobs, adjust the `mix_test_partition` here and the `--partitions option` in the `Run test` step.
+    # Example: 
+    # - mix_test_partition: [1, 2, 3, 4]
+    # - mix test --only feature_test --partitions 4
     strategy:
       matrix:
-        mix_test_partition: [1, 2, 3, 4]
+        mix_test_partition: [1]
 
     steps:
       - name: Checkout repository
@@ -379,7 +383,7 @@ jobs:
         run: mix ecto.migrate
 
       - name: Run Tests
-        run: mix test --only feature_test --partitions 4
+        run: mix test --only feature_test --partitions 1
         env:
           MIX_TEST_PARTITION: ${{ matrix.mix_test_partition }}
 


### PR DESCRIPTION
## What happened

When applying the template to a new project, the CI is failed on the feature test jobs.

## Insight

It's because we don't have enough tests to be partitioned, so there was no test run in one of the jobs -> failed

The solution is:

1/ Reduce the portion to just only 1 at the beginning.
2/ Add a comment on how to have parallel feature test jobs with partition.

## Proof Of Work

### Before

https://github.com/andyduong1920/demo-elixir-template-4-0/actions/runs/1926143124

![image](https://user-images.githubusercontent.com/11751745/156498013-81168d8b-b1af-45ba-9718-b056953bc905.png)


### After

https://github.com/andyduong1920/demo-elixir-template-4-0/actions/runs/1926153121

![image](https://user-images.githubusercontent.com/11751745/156497964-1e144d6f-f625-4564-955e-5506b972179b.png)
