### PR TITLE
Adjust the Heroku, Release, and Assets addon to make the app deployable 

### DIFF
--- a/lib/nimble_template/addons/github.ex
+++ b/lib/nimble_template/addons/github.ex
@@ -79,6 +79,8 @@ defmodule NimbleTemplate.Addons.Github do
       {:eex, ".github/workflows/deploy_heroku.yml", ".github/workflows/deploy_heroku.yml"}
     ])
 
+    Generator.replace_content("config/runtime.exs", "# ssl: true,", "ssl: true,")
+
     project
   end
 

--- a/lib/nimble_template/addons/github.ex
+++ b/lib/nimble_template/addons/github.ex
@@ -84,17 +84,6 @@ defmodule NimbleTemplate.Addons.Github do
     Generator.replace_content("config/runtime.exs", "# ssl: true,", "ssl: true,")
 
     Generator.replace_content(
-      "config/prod.exs",
-      """
-      config :#{otp_app}, #{web_module}.Endpoint,
-      """,
-      """
-      config :#{otp_app}, #{web_module}.Endpoint,
-        force_ssl: [rewrite_on: [:x_forwarded_proto]],
-      """
-    )
-
-    Generator.replace_content(
       "config/runtime.exs",
       "url: [host: host,",
       "url: [scheme: \"https\", host: host,"
@@ -112,6 +101,14 @@ defmodule NimbleTemplate.Addons.Github do
             Environment variable PHX_HOST is missing.
             Set the Heroku endpoint to this variable.
             \"\"\"
+      """
+    )
+
+    Generator.append_content(
+      "config/prod.exs",
+      """
+      config :#{otp_app}, #{web_module}.Endpoint,
+        force_ssl: [rewrite_on: [:x_forwarded_proto]]
       """
     )
 

--- a/lib/nimble_template/addons/github.ex
+++ b/lib/nimble_template/addons/github.ex
@@ -74,12 +74,31 @@ defmodule NimbleTemplate.Addons.Github do
   end
 
   @impl true
-  def do_apply(%Project{mix_project?: false} = project, %{github_action_deploy_heroku: true}) do
+  def do_apply(%Project{mix_project?: false, otp_app: otp_app, web_module: web_module} = project, %{
+        github_action_deploy_heroku: true
+      }) do
     Generator.copy_file([
       {:eex, ".github/workflows/deploy_heroku.yml", ".github/workflows/deploy_heroku.yml"}
     ])
 
     Generator.replace_content("config/runtime.exs", "# ssl: true,", "ssl: true,")
+
+    Generator.replace_content(
+      "config/prod.exs",
+      """
+      config :#{otp_app}, #{web_module}.Endpoint,
+      """,
+      """
+      config :#{otp_app}, #{web_module}.Endpoint,
+        force_ssl: [rewrite_on: [:x_forwarded_proto]],
+      """
+    )
+
+    Generator.replace_content(
+      "config/runtime.exs",
+      "url: [host: host,",
+      "url: [scheme: \"https\", host: host,"
+    )
 
     project
   end

--- a/lib/nimble_template/addons/github.ex
+++ b/lib/nimble_template/addons/github.ex
@@ -100,6 +100,21 @@ defmodule NimbleTemplate.Addons.Github do
       "url: [scheme: \"https\", host: host,"
     )
 
+    Generator.replace_content(
+      "config/runtime.exs",
+      """
+        host = System.get_env("PHX_HOST") || "example.com"
+      """,
+      """
+        host =
+          System.get_env("PHX_HOST") ||
+            raise \"\"\"
+            Environment variable PHX_HOST is missing.
+            Set the Heroku endpoint to this variable.
+            \"\"\"
+      """
+    )
+
     project
   end
 

--- a/lib/nimble_template/addons/github.ex
+++ b/lib/nimble_template/addons/github.ex
@@ -89,21 +89,6 @@ defmodule NimbleTemplate.Addons.Github do
       "url: [scheme: \"https\", host: host,"
     )
 
-    Generator.replace_content(
-      "config/runtime.exs",
-      """
-        host = System.get_env("PHX_HOST") || "example.com"
-      """,
-      """
-        host =
-          System.get_env("PHX_HOST") ||
-            raise \"\"\"
-            Environment variable PHX_HOST is missing.
-            Set the Heroku endpoint to this variable.
-            \"\"\"
-      """
-    )
-
     Generator.append_content(
       "config/prod.exs",
       """

--- a/lib/nimble_template/addons/variants/phoenix/mix_release.ex
+++ b/lib/nimble_template/addons/variants/phoenix/mix_release.ex
@@ -5,7 +5,9 @@ defmodule NimbleTemplate.Addons.Phoenix.MixRelease do
 
   @impl true
   def do_apply(%Project{} = project, _opts) do
-    copy_files(project)
+    project
+    |> copy_files()
+    |> edit_files()
 
     project
   end
@@ -19,6 +21,48 @@ defmodule NimbleTemplate.Addons.Phoenix.MixRelease do
       ],
       otp_app: otp_app,
       base_module: base_module
+    )
+
+    project
+  end
+
+  defp edit_files(%{otp_app: otp_app, web_module: web_module} = project) do
+    Generator.delete_content(
+      "config/runtime.exs",
+      """
+      # Start the phoenix server if environment is set and running in a release
+      if System.get_env("PHX_SERVER") && System.get_env("RELEASE_NAME") do
+        config :#{otp_app}, #{web_module}.Endpoint, server: true
+      end
+
+      """
+    )
+
+    Generator.delete_content(
+      "config/runtime.exs",
+      """
+
+        # ## Using releases
+        #
+        # If you are doing OTP releases, you need to instruct Phoenix
+        # to start each relevant endpoint:
+        #
+        #     config :#{otp_app}, #{web_module}.Endpoint, server: true
+        #
+        # Then you can assemble a release by calling `mix release`.
+        # See `mix help release` for more information.
+      """
+    )
+
+    Generator.replace_content(
+      "config/runtime.exs",
+      """
+        config :#{otp_app}, #{web_module}.Endpoint,
+      """,
+      """
+        config :#{otp_app}, #{web_module}.Endpoint,
+          server: true,
+      """
     )
 
     project

--- a/lib/nimble_template/addons/variants/phoenix/mix_release.ex
+++ b/lib/nimble_template/addons/variants/phoenix/mix_release.ex
@@ -65,6 +65,21 @@ defmodule NimbleTemplate.Addons.Phoenix.MixRelease do
       """
     )
 
+    Generator.replace_content(
+      "config/runtime.exs",
+      """
+        host = System.get_env("PHX_HOST") || "example.com"
+      """,
+      """
+        host =
+          System.get_env("PHX_HOST") ||
+            raise \"\"\"
+            Environment variable PHX_HOST is missing.
+            Set the Heroku endpoint to this variable.
+            \"\"\"
+      """
+    )
+
     project
   end
 end

--- a/priv/templates/nimble_template/.dockerignore
+++ b/priv/templates/nimble_template/.dockerignore
@@ -12,4 +12,3 @@ README.md
 cover
 **/tmp/
 doc
-/priv/static/

--- a/priv/templates/nimble_template/.github/wiki/Environment-Variables.md.eex
+++ b/priv/templates/nimble_template/.github/wiki/Environment-Variables.md.eex
@@ -8,3 +8,5 @@
 ### Endpoint configuration
 
 - `HEALTH_PATH`: Health path (eg: "/_health")
+- `PHX_HOST`: The application endpoint.
+- `SECRET_KEY_BASE`: Secret key base

--- a/priv/templates/nimble_template/.github/workflows/README.md.eex
+++ b/priv/templates/nimble_template/.github/workflows/README.md.eex
@@ -16,7 +16,8 @@ The following workflows are supported.
 - A Heroku API key. It can be generated under your [Account Settings](https://dashboard.heroku.com/account#api-key)
 - Three Heroku config vars:  
   - **DATABASE_URL**: It will be created automatically when the [PostgreSQL add-on](https://elements.heroku.com/addons/heroku-postgresql) is added.
-  - **HOST_URL**: if your app name is `acme`, the value of this var is: `acme.herokuapp.com`
+  - **PHX_HOST**: if your app name is `acme`, the value of this var is: `acme.herokuapp.com`
+  - **HEALTH_PATH**: Health path (eg: "/_health")
   - **SECRET_KEY_BASE**: use the `mix phx.gen.secret` to get a new secret and set it as the value of this var.
 
 ### How to use
@@ -24,32 +25,7 @@ The following workflows are supported.
 - Defining two [Github secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) to hold the value of Heroku API key and Heroku app name:
   - HEROKU_API_KEY
   - HEROKU_APP_NAME
-- Making some configuration changes to make the app ready for Heroku (read more in the [official documentation](https://hexdocs.pm/phoenix/heroku.html#making-our-project-ready-for-heroku)) that: 
-  tell Phoenix to use Heroku URL and enforce the SSL usage. Also, bind to the port requested by Heroku in the `$PORT` environment variable.
-
-  Find the `url` configuration in your `config/prod.exs`:
-
-  ```elixir
-  url: [host: "example.com", port: 80],
-  ```
-
-  and replace it with this:
-
-  ```elixir
-  http: [port: {:system, "PORT"}],
-  url: [scheme: "https", host: System.get_env("HOST_URL"), port: 443],
-  force_ssl: [rewrite_on: [:x_forwarded_proto]],
-  ```
-  
-  Enable SSL for production environment by uncomment it in the file `config/prod.secret.exs`:
-
-  ```elixir
-  config :gscraper_web, GscraperWeb.Repo,
-    ssl: true,
-    ...  
-  ```
-
-  If you plan on using WebSockets, the timeout for the WebSocket transport needs to be decreased in `lib/hello_web/endpoint.ex`.
+- If you plan on using WebSockets, the timeout for the WebSocket transport needs to be decreased in `lib/hello_web/endpoint.ex`.
 
   ```elixir
   socket "/socket", HelloWeb.UserSocket,

--- a/test/nimble_template/addons/github_test.exs
+++ b/test/nimble_template/addons/github_test.exs
@@ -287,6 +287,22 @@ defmodule NimbleTemplate.Addons.GithubTest do
         assert_file(".github/workflows/deploy_heroku.yml")
       end)
     end
+
+    test "enables ssl for Ecto", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      project = %{project | api_project?: true, web_project?: false}
+
+      in_test_project(test_project_path, fn ->
+        Addons.Github.apply(project, %{github_action_deploy_heroku: true})
+
+        assert_file("config/runtime.exs", fn file ->
+          assert file =~ "ssl: true,"
+          refute file =~ "# ssl: true,"
+        end)
+      end)
+    end
   end
 
   describe "#apply/2 with web_project and github_action_deploy_heroku option" do

--- a/test/nimble_template/addons/github_test.exs
+++ b/test/nimble_template/addons/github_test.exs
@@ -304,15 +304,6 @@ defmodule NimbleTemplate.Addons.GithubTest do
                    config :nimble_template, NimbleTemplate.Repo,
                      ssl: true,
                  """
-
-          assert file =~ """
-                   host =
-                     System.get_env("PHX_HOST") ||
-                       raise \"\"\"
-                       Environment variable PHX_HOST is missing.
-                       Set the Heroku endpoint to this variable.
-                       \"\"\"
-                 """
         end)
       end)
     end

--- a/test/nimble_template/addons/github_test.exs
+++ b/test/nimble_template/addons/github_test.exs
@@ -304,6 +304,15 @@ defmodule NimbleTemplate.Addons.GithubTest do
                    config :nimble_template, NimbleTemplate.Repo,
                      ssl: true,
                  """
+
+          assert file =~ """
+                   host =
+                     System.get_env("PHX_HOST") ||
+                       raise \"\"\"
+                       Environment variable PHX_HOST is missing.
+                       Set the Heroku endpoint to this variable.
+                       \"\"\"
+                 """
         end)
       end)
     end

--- a/test/nimble_template/addons/github_test.exs
+++ b/test/nimble_template/addons/github_test.exs
@@ -329,7 +329,7 @@ defmodule NimbleTemplate.Addons.GithubTest do
         assert_file("config/prod.exs", fn file ->
           assert file =~ """
                  config :nimble_template, NimbleTemplateWeb.Endpoint,
-                   force_ssl: [rewrite_on: [:x_forwarded_proto]],
+                   force_ssl: [rewrite_on: [:x_forwarded_proto]]
                  """
         end)
       end)

--- a/test/nimble_template/addons/variants/mix_release_test.exs
+++ b/test/nimble_template/addons/variants/mix_release_test.exs
@@ -46,6 +46,15 @@ defmodule NimbleTemplate.Addons.Phoenix.MixReleaseTest do
                      server: true,
                  """
 
+          assert file =~ """
+                   host =
+                     System.get_env("PHX_HOST") ||
+                       raise \"\"\"
+                       Environment variable PHX_HOST is missing.
+                       Set the Heroku endpoint to this variable.
+                       \"\"\"
+                 """
+
           refute file =~ """
 
                    # ## Using releases

--- a/test/nimble_template/addons/variants/mix_release_test.exs
+++ b/test/nimble_template/addons/variants/mix_release_test.exs
@@ -32,5 +32,42 @@ defmodule NimbleTemplate.Addons.Phoenix.MixReleaseTest do
         end)
       end)
     end
+
+    test "adjusts the config/runtime.exs", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        PhoenixAddons.MixRelease.apply(project)
+
+        assert_file("config/runtime.exs", fn file ->
+          assert file =~ """
+                   config :nimble_template, NimbleTemplateWeb.Endpoint,
+                     server: true,
+                 """
+
+          refute file =~ """
+
+                   # ## Using releases
+                   #
+                   # If you are doing OTP releases, you need to instruct Phoenix
+                   # to start each relevant endpoint:
+                   #
+                   #     config :nimble_template, NimbleTemplateWeb.Endpoint, server: true
+                   #
+                   # Then you can assemble a release by calling `mix release`.
+                   # See `mix help release` for more information.
+                 """
+
+          refute file =~ """
+                 # Start the phoenix server if environment is set and running in a release
+                 if System.get_env("PHX_SERVER") && System.get_env("RELEASE_NAME") do
+                   config :nimble_template, NimbleTemplateWeb.Endpoint, server: true
+                 end
+
+                 """
+        end)
+      end)
+    end
   end
 end


### PR DESCRIPTION
## What happened

The new generate project can't deploy to Heroku

## Insight

1/ [All Heroku Postgres client connections require SSL](https://devcenter.heroku.com/changelog-items/2035)

I have faced that error when testing the template

![Screen Shot 2022-03-03 at 13 41 14](https://user-images.githubusercontent.com/11751745/156513178-ee7a4d6a-d4e2-456f-98c9-a7dfe2c482e5.png)

Following the guide on https://hexdocs.pm/phoenix/heroku.html

![image](https://user-images.githubusercontent.com/11751745/156513654-94dccdb3-c1c5-4a8f-8d1d-3e8706cf393c.png)

Although we have some documentation for that in the Readme, and it requires some manual step to config, as the template we could make it ready to deploy by automate some step.

2/ Adjust the Release addon as there are some changes in the Elixir 1.13.3 and Phoenix 1.6.6 for the Runtime configuration part.

3/ Remove the `priv/static` in `.dockerignore` because in Phoenix 1.6, all asserts like images, fonts, will be placed in `priv/static` folder.

![image](https://user-images.githubusercontent.com/11751745/156535823-4f30d356-26e9-4a41-88cb-6948847bd154.png)

If we don't allow the `priv/static` folder there, the assets like images, fonts won't be copy and it's not on Production.

![image](https://user-images.githubusercontent.com/11751745/156535956-c34c6bd6-282e-4c6c-aa81-a1308ded654e.png)


## Proof Of Work

The test is passed, and the application can deployed to Heroku

1/ Test is passed https://github.com/andyduong1920/demo-elixir-template-4-0/actions/runs/1927159808

2/ Heroku app https://demo-elixir-template-4-0.herokuapp.com/
