### PR TITLE
Update Gettext addon

### DIFF
--- a/lib/nimble_template/addons/variants/phoenix/gettext.ex
+++ b/lib/nimble_template/addons/variants/phoenix/gettext.ex
@@ -17,32 +17,6 @@ defmodule NimbleTemplate.Addons.Phoenix.Gettext do
       """,
       """
         "gettext.extract-and-merge": ["gettext.extract --merge --no-fuzzy"],
-        "gettext.check": [
-          "gettext.extract-and-merge",
-          ~S/cmd git diff --no-ext-diff --quiet priv\\/gettext || echo "The localization files POs, POTs are NOT up-to-date."/
-        ],
-      """
-    )
-
-    Generator.replace_content(
-      "mix.exs",
-      """
-            "codebase.fix": [
-      """,
-      """
-            "codebase.fix": [
-              "gettext.extract-and-merge",
-      """
-    )
-
-    Generator.replace_content(
-      "mix.exs",
-      """
-        codebase: [
-      """,
-      """
-        codebase: [
-          "gettext.check",
       """
     )
 

--- a/priv/templates/nimble_template/.github/workflows/test.yml.eex
+++ b/priv/templates/nimble_template/.github/workflows/test.yml.eex
@@ -139,6 +139,15 @@ jobs:
       - name: Migrate database
         run: mix ecto.migrate
 
+      - name: Ensure that localization files (POs, POTs) are up-to-date.
+        run:
+          mix gettext.extract-and-merge;
+
+          if [ -n "$(git diff --exit-code priv/gettext/)" ]; then
+            echo "The localization files (POs, POTs) are NOT up-to-date, run \"mix gettext.extract-and-merge\" on your local and push again.";
+            exit 1;
+          fi
+
       - name: Run codebase check
         run: mix codebase
     

--- a/test/nimble_template/addons/variants/gettext_test.exs
+++ b/test/nimble_template/addons/variants/gettext_test.exs
@@ -4,7 +4,7 @@ defmodule NimbleTemplate.Addons.Phoenix.GettextTest do
   describe "#apply/2" do
     @describetag required_addons: [:TestEnv]
 
-    test "injects gettext.extract-and-merge command to mix aliases and codebase.fix", %{
+    test "injects gettext.extract-and-merge command to mix aliases", %{
       project: project,
       test_project_path: test_project_path
     } do
@@ -14,29 +14,6 @@ defmodule NimbleTemplate.Addons.Phoenix.GettextTest do
         assert_file("mix.exs", fn file ->
           assert file =~ """
                   "gettext.extract-and-merge": ["gettext.extract --merge --no-fuzzy"],
-                 """
-        end)
-
-        assert_file("mix.exs", fn file ->
-          assert file =~ """
-                   "gettext.check": [
-                     "gettext.extract-and-merge",
-                     ~S/cmd git diff --no-ext-diff --quiet priv\\/gettext || echo "The localization files POs, POTs are NOT up-to-date."/
-                   ],
-                 """
-        end)
-
-        assert_file("mix.exs", fn file ->
-          assert file =~ """
-                      "codebase.fix": [
-                         "gettext.extract-and-merge",
-                 """
-        end)
-
-        assert_file("mix.exs", fn file ->
-          assert file =~ """
-                   codebase: [
-                     "gettext.check",
                  """
         end)
       end)


### PR DESCRIPTION
## What happened

As the current command `git diff --no-ext-diff --quiet priv\\/gettext || echo "The localization files POs, POTs are NOT up-to-date."` does NOT work as expected, the CI always passed.

## Insight

Revert the Gettext addon, bring the Zipworld's solution to the template first, and the @byhbt can rework on the Gettext addon, Thanh was aware of the problem and we need time to think for another solution (doesn't rely on Git). So in terms of having this feature in this release, we can use this solution, the better solution can be applied in the next version.

## Proof Of Work

The test is passed, and the solution was applied in ZipWorld, well tested there.
