### PR TITLE
Update _sizing.scss

### DIFF
--- a/priv/templates/nimble_template/assets/nimble_css/functions/_sizing.scss
+++ b/priv/templates/nimble_template/assets/nimble_css/functions/_sizing.scss
@@ -5,7 +5,7 @@
     @if ($value == 0 or $value == auto) {
       $list: append($list, $value);
     } @else {
-      $rem-value: ($value / $base-font-size) + rem;
+      $rem-value: calc($value / $base-font-size) + rem;
       $list: append($list, $rem-value);
     }
   }

--- a/priv/templates/nimble_template/lib/otp_app_web/views/api/error_view.ex.eex
+++ b/priv/templates/nimble_template/lib/otp_app_web/views/api/error_view.ex.eex
@@ -5,7 +5,7 @@ defmodule <%= web_module %>.Api.ErrorView do
 
   def template_not_found(template, assigns) do
     build_error_response(
-      code: status_code_from_template(template),
+      code: assigns[:code] || status_code_from_template(template),
       detail: %{},
       message: assigns[:message] || Phoenix.Controller.status_message_from_template(template)
     )

--- a/priv/templates/nimble_template/test/otp_app_web/views/api/error_view_test.exs
+++ b/priv/templates/nimble_template/test/otp_app_web/views/api/error_view_test.exs
@@ -58,7 +58,7 @@ defmodule <%= web_module %>.Api.ErrorViewTest do
     assert render(ErrorView, "500.json", status: 500, code: :custom_error_code) ==
              %{
                errors: [
-                 %{code: :custom_error_code, detail: %{}, message: "Something went wrong"}
+                 %{code: :custom_error_code, detail: %{}, message: "Internal Server Error"}
                ]
              }
   end

--- a/priv/templates/nimble_template/test/otp_app_web/views/api/error_view_test.exs
+++ b/priv/templates/nimble_template/test/otp_app_web/views/api/error_view_test.exs
@@ -54,6 +54,15 @@ defmodule <%= web_module %>.Api.ErrorViewTest do
              }
   end
 
+  test "renders custom error code" do
+    assert render(ErrorView, "500.json", status: 500, code: :custom_error_code) ==
+             %{
+               errors: [
+                 %{code: :custom_error_code, detail: %{}, message: "Something went wrong"}
+               ]
+             }
+  end
+
   test "given error code and an invalid changeset with multiple errors fields, renders error.json" do
     changeset = Device.changeset(%{})
     error = %{code: :validation_error, changeset: changeset}


### PR DESCRIPTION
## What happened

![image](https://user-images.githubusercontent.com/11751745/163986307-90db2ec9-2012-43b1-904f-3116008cabe5.png)


## Insight

Just following the instruction.

I also take this chance to update the `priv/templates/nimble_template/lib/otp_app_web/views/api/error_view.ex.eex` a bit to make it work with `custom` code value.

## Proof Of Work

No more warning on client project
