### PR TITLE
Fix dart-sass lib incombility issue with Mac M1

### DIFF
--- a/lib/nimble_template/addons/variants/phoenix/web/dart_sass.ex
+++ b/lib/nimble_template/addons/variants/phoenix/web/dart_sass.ex
@@ -3,7 +3,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.DartSass do
 
   use NimbleTemplate.Addons.Addon
 
-  @dart_sass_version "1.49.8"
+  @dart_sass_version "1.51.0"
 
   @impl true
   def do_apply(%Project{} = project, _opts) do

--- a/test/nimble_template/addons/variants/phoenix/web/dart_sass_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/dart_sass_test.exs
@@ -52,7 +52,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.DartSassTest do
           assert file =~ """
                  # Configure dart_sass (the version is required)
                  config :dart_sass,
-                   version: "1.49.8",
+                   version: "1.51.0",
                    default: [
                      args: ~w(
                        --load-path=./node_modules


### PR DESCRIPTION
## What happened

`dart-sass` lib added binaries for arm64 architecture (mac m1 in my case) only in [1.49.11](https://github.com/sass/dart-sass/releases/tag/1.49.11) release.

In the template we are using `1.49.8` version which leads to error on start app command:
```
[debug] Downloading dart-sass from https://github.com/sass/dart-sass/releases/download/1.49.8/dart-sass-1.49.8-macos-arm64.tar.gz
[error] Task #PID<0.672.0> started from GoogleScrapingWeb.Endpoint terminating
** (RuntimeError) couldn't fetch https://github.com/sass/dart-sass/releases/download/1.49.8/dart-sass-1.49.8-macos-arm64.tar.gz: {:ok, {{'HTTP/1.1', 404, 'Not Found'}, [{'cache-control', 'no-cache'}, {'date', 'Mon, 09 May 2022 08:35:18 GMT'}, {'server', 'GitHub.com'}, {'vary', 'X-PJAX, X-PJAX-Container, Accept-Encoding, Accept, X-Requested-With'}, {'content-length', '9'}, {'content-type', 'text/plain; charset=utf-8'}, {'permissions-policy', 'interest-cohort=()'}, {'strict-transport-security', 'max-age=31536000; includeSubdomains; preload'}, {'x-frame-options', 'deny'}, {'x-content-type-options', 'nosniff'}, {'x-xss-protection', '0'}, {'referrer-policy', 'no-referrer-when-downgrade'}, {'expect-ct', 'max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"'}, {'content-security-policy', 'default-src \'none\'; base-uri \'self\'; connect-src \'self\'; form-action \'self\'; img-src \'self\' data:; script-src \'self\'; style-src \'unsafe-inline\''}, {'x-github-request-id', 'C16F:3439:8E0C4:DAF6D:6278D250'}], 'Not Found'}}
    (dart_sass 0.5.0) lib/dart_sass.ex:388: DartSass.fetch_body!/1
    (dart_sass 0.5.0) lib/dart_sass.ex:231: DartSass.install/0
    (dart_sass 0.5.0) lib/dart_sass.ex:210: DartSass.install_and_run/2
    (phoenix 1.6.8) lib/phoenix/endpoint/watcher.ex:19: Phoenix.Endpoint.Watcher.watch/2
    (elixir 1.13.4) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
    (stdlib 3.17.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Function: &Phoenix.Endpoint.Watcher.watch/2
    Args: ["sass", {DartSass, :install_and_run, [:default, ["--embed-source-map", "--source-map-urls=absolute", "--watch"]]}]
```

## Insight

It looks like everything is working fine if we upgrade `dart-sass` lib to the latest version (`1.51.0`). There are no breaking changes between current version and latest one that affects template project.

## Proof Of Work

<img width="981" alt="image" src="https://user-images.githubusercontent.com/475367/167378372-1a811c61-9da8-4f33-94ef-6053f3e4f8a1.png">
