### PR TITLE
Fix the Icon Sprite

### DIFF
--- a/lib/nimble_template/addons/variants/phoenix/web/svg_sprite.ex
+++ b/lib/nimble_template/addons/variants/phoenix/web/svg_sprite.ex
@@ -35,7 +35,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.SvgSprite do
       """,
       """
         "scripts": {
-          "svg-sprite.generate-icon": "svg-sprite --shape-id-generator \\"icon-%s\\" --symbol --symbol-dest static/images --symbol-sprite icon-sprite.svg static/images/icons/*.svg",
+          "svg-sprite.generate-icon": "svg-sprite --shape-id-generator \\"icon-%s\\" --symbol --symbol-dest ../priv/static/images --symbol-sprite icon-sprite.svg ../priv/static/images/icons/*.svg",
       """
     )
 

--- a/priv/templates/nimble_template/.github/wiki/Icon-Sprite.md
+++ b/priv/templates/nimble_template/.github/wiki/Icon-Sprite.md
@@ -2,17 +2,17 @@
 
 1. Export SVG icon from Figma.
 
-2. Add icon file to `assets/static/images/icons/` (without the `icon-` prefix).
+2. Add icon file to `priv/static/images/icons/` (without the `icon-` prefix) (e.g. `active.svg`).
 
 3. Generate/Update the `icon-sprite.svg` by running this command:
-
-  ```sh
-  npm run svg-sprite.generate-icon --prefix assets
-  ```
+   ```sh
+   npm run svg-sprite.generate-icon --prefix assets
+   ```
 
 ## Using Icon Sprite in Template
 
 ```sh
-<%= icon_tag(@conn, "icon-active", class: "something") %>
-# <svg class=\"something icon\"><use xlink:href=\"/images/icon-sprite.svg#icon-active\"></svg>
+<%= icon_tag(@conn, "active", class: "something") %>
+
+# <svg class=\"icon something\"><use xlink:href=\"/images/icon-sprite.svg#icon-priv--static--images--icons--active\"></svg>
 ```

--- a/priv/templates/nimble_template/lib/otp_app_web/helpers/icon_helper.ex.eex
+++ b/priv/templates/nimble_template/lib/otp_app_web/helpers/icon_helper.ex.eex
@@ -7,11 +7,19 @@ defmodule <%= web_module %>.IconHelper do
 
   alias <%= web_module %>.Router.Helpers, as: Routes
 
-  def icon_tag(conn, name, opts \\ []) do
+  @svg_shape_id_prefix "icon-priv--static--images--icons--"
+  
+  def icon_tag(conn, icon_file_name, opts \\ []) do
     classes = "icon " <> Keyword.get(opts, :class, "")
 
     content_tag(:svg, class: classes) do
-      tag(:use, "xlink:href": Routes.static_path(conn, "/images/icon-sprite.svg#" <> name))
+      tag(:use,
+        "xlink:href":
+          Routes.static_path(
+            conn,
+            "/images/icon-sprite.svg#" <> @svg_shape_id_prefix <> icon_file_name
+          )
+      )
     end
   end
 end

--- a/priv/templates/nimble_template/test/otp_app_web/helpers/icon_helper_test.exs.eex
+++ b/priv/templates/nimble_template/test/otp_app_web/helpers/icon_helper_test.exs.eex
@@ -7,13 +7,21 @@ defmodule <%= web_module %>.IconHelperTest do
 
   describe "icon_tag/3" do
     test "renders a svg icon" do
-      image =
+      first_svg_icon =
         <%= web_module %>.Endpoint
         |> IconHelper.icon_tag("active", class: "customize-icon-class")
         |> safe_to_string()
 
-      assert image ==
-               "<svg class=\"icon customize-icon-class\"><use xlink:href=\"/images/icon-sprite.svg#active\"></svg>"
+      second_svg_icon =
+        <%= web_module %>.Endpoint
+        |> IconHelper.icon_tag("icon-lock")
+        |> safe_to_string()
+
+      assert first_svg_icon ==
+               "<svg class=\"icon customize-icon-class\"><use xlink:href=\"/images/icon-sprite.svg#icon-priv--static--images--icons--active\"></svg>"
+
+      assert second_svg_icon ==
+               "<svg class=\"icon \"><use xlink:href=\"/images/icon-sprite.svg#icon-priv--static--images--icons--icon-lock\"></svg>"
     end
   end
 end

--- a/test/nimble_template/addons/variants/phoenix/web/svg_sprite_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/svg_sprite_test.exs
@@ -30,7 +30,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.SvgSpriteTest do
         assert_file("assets/package.json", fn file ->
           assert file =~ """
                    "scripts": {
-                     "svg-sprite.generate-icon": "svg-sprite --shape-id-generator \\"icon-%s\\" --symbol --symbol-dest static/images --symbol-sprite icon-sprite.svg static/images/icons/*.svg",
+                     "svg-sprite.generate-icon": "svg-sprite --shape-id-generator \\"icon-%s\\" --symbol --symbol-dest ../priv/static/images --symbol-sprite icon-sprite.svg ../priv/static/images/icons/*.svg",
                  """
         end)
       end)


### PR DESCRIPTION
## What happened

The SVG sprite needs to be updated due to the `migration to EsBuild`

## Insight

1/ Update the `generate CLI command` as we moved the images to `priv` folder already.
2/ Update the IconHelper to include the `priv--static--images--icons--` because the icon files now located in the `priv/static/images/icons` folder, which is different with the `assets/package.json` location, the SVG sprite generate the `path to the sharp id` 

## Proof Of Work

Tested on client project.
