### PR TITLE
Get around to not working live refresh CSS 

### DIFF
--- a/lib/nimble_template/addons/variants/phoenix/web/dart_sass.ex
+++ b/lib/nimble_template/addons/variants/phoenix/web/dart_sass.ex
@@ -3,7 +3,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.DartSass do
 
   use NimbleTemplate.Addons.Addon
 
-  @dart_sass_version "1.51.0"
+  @dart_sass_version "1.49.11"
 
   @impl true
   def do_apply(%Project{} = project, _opts) do

--- a/test/nimble_template/addons/variants/phoenix/web/dart_sass_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/dart_sass_test.exs
@@ -52,7 +52,7 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.DartSassTest do
           assert file =~ """
                  # Configure dart_sass (the version is required)
                  config :dart_sass,
-                   version: "1.51.0",
+                   version: "1.49.11",
                    default: [
                      args: ~w(
                        --load-path=./node_modules


### PR DESCRIPTION
## What happened

In previous PR `dart-sass` lib was updated to the latest version to avoid incompatibility with M1 laptops: https://github.com/nimblehq/elixir-templates/pull/200

But it turned out that in the new version of `dart-sass` live refresh for styles is not working: https://github.com/CargoSense/dart_sass/issues/26

In this PR pinned the `1.49.11` version which is both suitable for M1 laptops and is supporting live refreshing correctly.
