### PR TITLE
Add `node version` into `.tool-version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ NimbleTemplate has been developed and actively tested with the below environment
 - Elixir 1.13.3
 - Erlang/OTP 24.2.2
 - Phoenix 1.6.6
+- Node 16.15.0
 
 ## Installation
 

--- a/lib/nimble_template/addons/asdf_tool_version.ex
+++ b/lib/nimble_template/addons/asdf_tool_version.ex
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.ElixirVersion do
+defmodule NimbleTemplate.Addons.AsdfToolVersion do
   @moduledoc false
 
   use NimbleTemplate.Addons.Addon

--- a/lib/nimble_template/addons/asdf_tool_version.ex
+++ b/lib/nimble_template/addons/asdf_tool_version.ex
@@ -7,7 +7,9 @@ defmodule NimbleTemplate.Addons.AsdfToolVersion do
   def do_apply(
         %Project{
           erlang_version: erlang_version,
-          elixir_asdf_version: elixir_asdf_version
+          elixir_asdf_version: elixir_asdf_version,
+          node_asdf_version: node_asdf_version,
+          web_project?: web_project?
         } = project,
         _opts
       ) do
@@ -15,6 +17,15 @@ defmodule NimbleTemplate.Addons.AsdfToolVersion do
       erlang_version: erlang_version,
       elixir_asdf_version: elixir_asdf_version
     )
+
+    if web_project? do
+      Generator.append_content(
+        ".tool-versions",
+        """
+        nodejs #{node_asdf_version}
+        """
+      )
+    end
 
     project
   end

--- a/lib/nimble_template/addons/github.ex
+++ b/lib/nimble_template/addons/github.ex
@@ -143,13 +143,15 @@ defmodule NimbleTemplate.Addons.Github do
            web_project?: web_project?,
            mix_project?: false,
            erlang_version: erlang_version,
-           elixir_version: elixir_version
+           elixir_version: elixir_version,
+           node_asdf_version: node_asdf_version
          } = project
        ) do
     binding = [
       web_project?: web_project?,
       erlang_version: erlang_version,
-      elixir_version: elixir_version
+      elixir_version: elixir_version,
+      node_asdf_version: node_asdf_version
     ]
 
     publish_wiki_workflow_path = ".github/workflows/publish_wiki.yml"

--- a/lib/nimble_template/addons/readme.ex
+++ b/lib/nimble_template/addons/readme.ex
@@ -21,7 +21,8 @@ defmodule NimbleTemplate.Addons.Readme do
            web_project?: web_project?,
            mix_project?: mix_project?,
            erlang_version: erlang_version,
-           elixir_version: elixir_version
+           elixir_version: elixir_version,
+           node_asdf_version: node_asdf_version
          } = project
        ) do
     template_file_path =
@@ -34,6 +35,7 @@ defmodule NimbleTemplate.Addons.Readme do
     Generator.copy_file([{:eex, template_file_path, "README.md"}],
       erlang_version: erlang_version,
       elixir_version: elixir_version,
+      node_asdf_version: node_asdf_version,
       web_project?: web_project?
     )
 

--- a/lib/nimble_template/projects/project.ex
+++ b/lib/nimble_template/projects/project.ex
@@ -5,6 +5,7 @@ defmodule NimbleTemplate.Projects.Project do
   @elixir_version "1.13.3"
   @erlang_version "24.2.2"
   @node_version "16"
+  @node_asdf_version "16.15.0"
 
   defstruct base_module: nil,
             base_path: nil,
@@ -19,6 +20,7 @@ defmodule NimbleTemplate.Projects.Project do
             elixir_asdf_version:
               "#{@elixir_version}-otp-#{@erlang_version |> String.split(".") |> List.first()}",
             erlang_version: @erlang_version,
+            node_asdf_version: @node_asdf_version,
             node_version: @node_version,
             # Variants
             api_project?: false,

--- a/lib/nimble_template/templates/variants/mix/template.ex
+++ b/lib/nimble_template/templates/variants/mix/template.ex
@@ -14,7 +14,7 @@ defmodule NimbleTemplate.Templates.Mix.Template do
 
   defp apply_default_mix_addons(project) do
     project
-    |> Addons.ElixirVersion.apply()
+    |> Addons.AsdfToolVersion.apply()
     |> Addons.Readme.apply()
     |> Addons.TestEnv.apply()
     |> Addons.Credo.apply()

--- a/lib/nimble_template/templates/variants/phoenix/template.ex
+++ b/lib/nimble_template/templates/variants/phoenix/template.ex
@@ -31,7 +31,7 @@ defmodule NimbleTemplate.Templates.Phoenix.Template do
 
   defp apply_default_common_addons(project) do
     project
-    |> Addons.ElixirVersion.apply()
+    |> Addons.AsdfToolVersion.apply()
     |> Addons.Readme.apply()
     |> Addons.TestEnv.apply()
     |> Addons.Credo.apply()

--- a/priv/templates/nimble_template/.github/wiki/Getting-Started.md.eex
+++ b/priv/templates/nimble_template/.github/wiki/Getting-Started.md.eex
@@ -3,12 +3,19 @@
 - Erlang <%= erlang_version %>
 
 - Elixir <%= elixir_version %>
+<%= if web_project? do %>
+### Node
 
+- Node <%= node_asdf_version %>
+<% end %>
 - Recommended version manager.
 
   - [asdf](https://github.com/asdf-vm/asdf)
   - [asdf-erlang](https://github.com/asdf-vm/asdf-erlang)
   - [asdf-elixir](https://github.com/asdf-vm/asdf-elixir)
+<%= if web_project? do %>
+  - [asdf-node](https://github.com/asdf-vm/asdf-node)
+<% end %>
 
 ## Development
 

--- a/priv/templates/nimble_template/.tool-versions.eex
+++ b/priv/templates/nimble_template/.tool-versions.eex
@@ -1,3 +1,6 @@
 # Configuration file for https://github.com/asdf-vm/asdf
 erlang <%= erlang_version %>
 elixir <%= elixir_asdf_version %>
+<%= if web_project? do %>
+nodejs <%= node_asdf_version %>
+<% end %>

--- a/priv/templates/nimble_template/.tool-versions.eex
+++ b/priv/templates/nimble_template/.tool-versions.eex
@@ -1,6 +1,3 @@
 # Configuration file for https://github.com/asdf-vm/asdf
 erlang <%= erlang_version %>
 elixir <%= elixir_asdf_version %>
-<%= if web_project? do %>
-nodejs <%= node_asdf_version %>
-<% end %>

--- a/priv/templates/nimble_template/README.md.eex
+++ b/priv/templates/nimble_template/README.md.eex
@@ -11,12 +11,19 @@
 - Erlang <%= erlang_version %>
 
 - Elixir <%= elixir_version %>
+<%= if web_project? do %>
+### Node
 
+- Node <%= node_asdf_version %>
+<% end %>
 - Recommended version manager.
 
   - [asdf](https://github.com/asdf-vm/asdf)
   - [asdf-erlang](https://github.com/asdf-vm/asdf-erlang)
   - [asdf-elixir](https://github.com/asdf-vm/asdf-elixir)
+<%= if web_project? do %>
+  - [asdf-node](https://github.com/asdf-vm/asdf-node)
+<% end %>
 
 ### Development
 

--- a/test/nimble_template/addons/asdf_tool_version_test.exs
+++ b/test/nimble_template/addons/asdf_tool_version_test.exs
@@ -1,7 +1,50 @@
 defmodule NimbleTemplate.Addons.AsdfToolVersionTest do
   use NimbleTemplate.AddonCase, async: false
 
-  describe "#apply/2" do
+  describe "#apply/2 with web_project" do
+    test "copies the .tool-versions", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        Addons.AsdfToolVersion.apply(project)
+
+        assert_file(".tool-versions", fn file ->
+          assert file =~ """
+                 erlang 24.2.2
+                 elixir 1.13.3-otp-24
+                 nodejs 16.15.0
+                 """
+        end)
+      end)
+    end
+  end
+
+  describe "#apply/2 with api_project" do
+    test "copies the .tool-versions", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      project = %{project | api_project?: true, web_project?: false}
+
+      in_test_project(test_project_path, fn ->
+        Addons.AsdfToolVersion.apply(project)
+
+        assert_file(".tool-versions", fn file ->
+          assert file =~ """
+                 erlang 24.2.2
+                 elixir 1.13.3-otp-24
+                 """
+
+          refute file =~ "nodejs 16.15.0"
+        end)
+      end)
+    end
+  end
+
+  describe "#apply/2 with mix_project" do
+    @describetag mix_project?: true
+
     test "copies the .tool-versions", %{
       project: project,
       test_project_path: test_project_path
@@ -14,6 +57,8 @@ defmodule NimbleTemplate.Addons.AsdfToolVersionTest do
                  erlang 24.2.2
                  elixir 1.13.3-otp-24
                  """
+
+          refute file =~ "nodejs 16.15.0"
         end)
       end)
     end

--- a/test/nimble_template/addons/asdf_tool_version_test.exs
+++ b/test/nimble_template/addons/asdf_tool_version_test.exs
@@ -1,4 +1,4 @@
-defmodule NimbleTemplate.Addons.ElixirVersionTest do
+defmodule NimbleTemplate.Addons.AsdfToolVersionTest do
   use NimbleTemplate.AddonCase, async: false
 
   describe "#apply/2" do
@@ -7,7 +7,7 @@ defmodule NimbleTemplate.Addons.ElixirVersionTest do
       test_project_path: test_project_path
     } do
       in_test_project(test_project_path, fn ->
-        Addons.ElixirVersion.apply(project)
+        Addons.AsdfToolVersion.apply(project)
 
         assert_file(".tool-versions", fn file ->
           assert file =~ """

--- a/test/nimble_template/addons/github_test.exs
+++ b/test/nimble_template/addons/github_test.exs
@@ -369,6 +369,9 @@ defmodule NimbleTemplate.Addons.GithubTest do
           assert file =~ "Erlang 24.2.2"
           assert file =~ "Elixir 1.13.3"
 
+          assert file =~ "Node 16.15.0"
+          assert file =~ "- [asdf-node](https://github.com/asdf-vm/asdf-node)"
+
           assert file =~ """
                  - Install Node dependencies:
 
@@ -442,6 +445,9 @@ defmodule NimbleTemplate.Addons.GithubTest do
           assert file =~ "Erlang 24.2.2"
           assert file =~ "Elixir 1.13.3"
 
+          refute file =~ "Node 16.15.0"
+          refute file =~ "- [asdf-node](https://github.com/asdf-vm/asdf-node)"
+
           refute file =~ """
                       - Install Node dependencies:
 
@@ -497,6 +503,9 @@ defmodule NimbleTemplate.Addons.GithubTest do
         assert_file(".github/wiki/Getting-Started.md", fn file ->
           assert file =~ "Erlang 24.2.2"
           assert file =~ "Elixir 1.13.3"
+
+          refute file =~ "Node 16.15.0"
+          refute file =~ "- [asdf-node](https://github.com/asdf-vm/asdf-node)"
 
           refute file =~ """
                       - Install Node dependencies:

--- a/test/nimble_template/addons/readme_test.exs
+++ b/test/nimble_template/addons/readme_test.exs
@@ -13,6 +13,9 @@ defmodule NimbleTemplate.Addons.ReadmeTest do
           assert file =~ "Erlang 24.2.2"
           assert file =~ "Elixir 1.13.3"
 
+          assert file =~ "Node 16.15.0"
+          assert file =~ "- [asdf-node](https://github.com/asdf-vm/asdf-node)"
+
           assert file =~ """
                  - Install Node dependencies:
 
@@ -47,6 +50,9 @@ defmodule NimbleTemplate.Addons.ReadmeTest do
           assert file =~ "Erlang 24.2.2"
           assert file =~ "Elixir 1.13.3"
 
+          refute file =~ "Node 16.15.0"
+          refute file =~ "- [asdf-node](https://github.com/asdf-vm/asdf-node)"
+
           refute file =~ """
                  - Install Node dependencies:
 
@@ -80,6 +86,9 @@ defmodule NimbleTemplate.Addons.ReadmeTest do
         assert_file("README.md", fn file ->
           assert file =~ "Erlang 24.2.2"
           assert file =~ "Elixir 1.13.3"
+
+          refute file =~ "Node 16.15.0"
+          refute file =~ "- [asdf-node](https://github.com/asdf-vm/asdf-node)"
 
           refute file =~ """
                  - Install Node dependencies:


### PR DESCRIPTION
## What happened

As some of our members prefer to define the node version in `.tool-versions` through the asdf 

![image](https://user-images.githubusercontent.com/11751745/168953323-b43a8093-d275-4691-adc5-657b7f8f4b46.png)

## Insight

Just edit the `.tool-versions` file

## Proof Of Work

The test is passed
