### PR TITLE
Use version from asdf .tool-version for the template.

### DIFF
--- a/.github/workflows/publish_to_hex_pm.yml
+++ b/.github/workflows/publish_to_hex_pm.yml
@@ -29,8 +29,14 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
-      - name: Install .tool-versions.
+      - name: Install dependencies in .tool-versions
         uses: asdf-vm/actions/install@v1
+        
+      - name: Install rebar
+        run: mix local.rebar --force
+        
+      - name: Install hex
+        run: mix local.hex --force
 
       - name: Cache Elixir build
         uses: actions/cache@v2

--- a/.github/workflows/publish_to_hex_pm.yml
+++ b/.github/workflows/publish_to_hex_pm.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install dependencies in .tool-versions
         if: steps.asdf-cache.outputs.cache-hit != 'true'
-        uses: asdf-vm/actions/install@v13
+        uses: asdf-vm/actions/install@v1
         
       - name: Install rebar
         run: mix local.rebar --force

--- a/.github/workflows/publish_to_hex_pm.yml
+++ b/.github/workflows/publish_to_hex_pm.yml
@@ -29,8 +29,22 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
+      - name: Setup asdf
+        uses: asdf-vm/actions/setup@v1
+
+      - name: Cache asdf
+        id: asdf-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            /home/runner/.asdf
+          key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
+          restore-keys: |
+            ${{ runner.os }}-asdf-
+
       - name: Install dependencies in .tool-versions
-        uses: asdf-vm/actions/install@v1
+        if: steps.asdf-cache.outputs.cache-hit != 'true'
+        uses: asdf-vm/actions/install@v13
         
       - name: Install rebar
         run: mix local.rebar --force

--- a/.github/workflows/publish_to_hex_pm.yml
+++ b/.github/workflows/publish_to_hex_pm.yml
@@ -33,7 +33,6 @@ jobs:
         uses: asdf-vm/actions/setup@v1
 
       - name: Cache asdf
-        id: asdf-cache
         uses: actions/cache@v2
         with:
           path: |
@@ -43,7 +42,6 @@ jobs:
             ${{ runner.os }}-asdf-
 
       - name: Install dependencies in .tool-versions
-        if: steps.asdf-cache.outputs.cache-hit != 'true'
         uses: asdf-vm/actions/install@v1
         
       - name: Install rebar

--- a/.github/workflows/publish_to_hex_pm.yml
+++ b/.github/workflows/publish_to_hex_pm.yml
@@ -35,11 +35,9 @@ jobs:
       - name: Cache asdf
         uses: actions/cache@v2
         with:
-          path: |
-            /home/runner/.asdf
+          path: /home/runner/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
-          restore-keys: |
-            ${{ runner.os }}-asdf-
+          restore-keys: ${{ runner.os }}-asdf-
 
       - name: Install dependencies in .tool-versions
         uses: asdf-vm/actions/install@v1
@@ -57,8 +55,7 @@ jobs:
             _build
             deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-mix-
+          restore-keys: ${{ runner.os }}-mix-
 
       - name: Install Dependencies
         run: mix deps.get

--- a/.github/workflows/publish_to_hex_pm.yml
+++ b/.github/workflows/publish_to_hex_pm.yml
@@ -10,10 +10,6 @@ on:
       - completed
   workflow_dispatch:
 
-env:
-  OTP_VERSION: 24.2.2
-  ELIXIR_VERSION: 1.13.3
-
 jobs:
   publish:
     name: Publish hex package
@@ -33,11 +29,8 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
-      - name: Set up Elixir ${{ env.ELIXIR_VERSION }} and OTP ${{ env.OTP_VERSION }}
-        uses: erlef/setup-elixir@v1
-        with:
-          otp-version: ${{ env.OTP_VERSION }}
-          elixir-version: ${{ env.ELIXIR_VERSION }}
+      - name: Install .tool-versions.
+        uses: asdf-vm/actions/install@v1
 
       - name: Cache Elixir build
         uses: actions/cache@v2

--- a/.github/workflows/publish_to_hex_pm.yml
+++ b/.github/workflows/publish_to_hex_pm.yml
@@ -20,12 +20,12 @@ jobs:
     
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
@@ -33,7 +33,7 @@ jobs:
         uses: asdf-vm/actions/setup@v1
 
       - name: Cache asdf
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
@@ -49,7 +49,7 @@ jobs:
         run: mix local.hex --force
 
       - name: Cache Elixir build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             _build

--- a/.github/workflows/reusable_mix_project.yml
+++ b/.github/workflows/reusable_mix_project.yml
@@ -8,8 +8,6 @@ on:
         type: string
 
 env:
-  OTP_VERSION: 24.2.2
-  ELIXIR_VERSION: 1.13.3
   BASE_PROJECT_DIRECTORY: sample_project
   MIX_ENV: test
   
@@ -29,11 +27,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Set up Elixir ${{ env.ELIXIR_VERSION }} and OTP ${{ env.OTP_VERSION }}
-        uses: erlef/setup-elixir@v1
-        with:
-          otp-version: ${{ env.OTP_VERSION }}
-          elixir-version: ${{ env.ELIXIR_VERSION }}
+      - name: Install .tool-versions.
+        uses: asdf-vm/actions/install@v1
       
       - name: Create Mix project
         run: make create_mix_project PROJECT_DIRECTORY=$BASE_PROJECT_DIRECTORY OPTIONS="${{ inputs.new_project_options }}"

--- a/.github/workflows/reusable_mix_project.yml
+++ b/.github/workflows/reusable_mix_project.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install dependencies in .tool-versions
         if: steps.asdf-cache.outputs.cache-hit != 'true'
-        uses: asdf-vm/actions/install@v13
+        uses: asdf-vm/actions/install@v1
         
       - name: Install rebar
         run: mix local.rebar --force

--- a/.github/workflows/reusable_mix_project.yml
+++ b/.github/workflows/reusable_mix_project.yml
@@ -31,7 +31,6 @@ jobs:
         uses: asdf-vm/actions/setup@v1
 
       - name: Cache asdf
-        id: asdf-cache
         uses: actions/cache@v2
         with:
           path: |
@@ -41,7 +40,6 @@ jobs:
             ${{ runner.os }}-asdf-
 
       - name: Install dependencies in .tool-versions
-        if: steps.asdf-cache.outputs.cache-hit != 'true'
         uses: asdf-vm/actions/install@v1
         
       - name: Install rebar

--- a/.github/workflows/reusable_mix_project.yml
+++ b/.github/workflows/reusable_mix_project.yml
@@ -27,8 +27,22 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
+      - name: Setup asdf
+        uses: asdf-vm/actions/setup@v1
+
+      - name: Cache asdf
+        id: asdf-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            /home/runner/.asdf
+          key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
+          restore-keys: |
+            ${{ runner.os }}-asdf-
+
       - name: Install dependencies in .tool-versions
-        uses: asdf-vm/actions/install@v1
+        if: steps.asdf-cache.outputs.cache-hit != 'true'
+        uses: asdf-vm/actions/install@v13
         
       - name: Install rebar
         run: mix local.rebar --force

--- a/.github/workflows/reusable_mix_project.yml
+++ b/.github/workflows/reusable_mix_project.yml
@@ -27,8 +27,14 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Install .tool-versions.
+      - name: Install dependencies in .tool-versions
         uses: asdf-vm/actions/install@v1
+        
+      - name: Install rebar
+        run: mix local.rebar --force
+        
+      - name: Install hex
+        run: mix local.hex --force
       
       - name: Create Mix project
         run: make create_mix_project PROJECT_DIRECTORY=$BASE_PROJECT_DIRECTORY OPTIONS="${{ inputs.new_project_options }}"

--- a/.github/workflows/reusable_mix_project.yml
+++ b/.github/workflows/reusable_mix_project.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
 
@@ -31,7 +31,7 @@ jobs:
         uses: asdf-vm/actions/setup@v1
 
       - name: Cache asdf
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}

--- a/.github/workflows/reusable_mix_project.yml
+++ b/.github/workflows/reusable_mix_project.yml
@@ -33,11 +33,9 @@ jobs:
       - name: Cache asdf
         uses: actions/cache@v2
         with:
-          path: |
-            /home/runner/.asdf
+          path: /home/runner/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
-          restore-keys: |
-            ${{ runner.os }}-asdf-
+          restore-keys: ${{ runner.os }}-asdf-
 
       - name: Install dependencies in .tool-versions
         uses: asdf-vm/actions/install@v1

--- a/.github/workflows/reusable_phoenix_project.yml
+++ b/.github/workflows/reusable_phoenix_project.yml
@@ -48,11 +48,9 @@ jobs:
       - name: Cache asdf
         uses: actions/cache@v2
         with:
-          path: |
-            /home/runner/.asdf
+          path: /home/runner/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
-          restore-keys: |
-            ${{ runner.os }}-asdf-
+          restore-keys: ${{ runner.os }}-asdf-
 
       - name: Install dependencies in .tool-versions
         uses: asdf-vm/actions/install@v1

--- a/.github/workflows/reusable_phoenix_project.yml
+++ b/.github/workflows/reusable_phoenix_project.yml
@@ -42,8 +42,22 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
+      - name: Setup asdf
+        uses: asdf-vm/actions/setup@v1
+
+      - name: Cache asdf
+        id: asdf-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            /home/runner/.asdf
+          key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
+          restore-keys: |
+            ${{ runner.os }}-asdf-
+
       - name: Install dependencies in .tool-versions
-        uses: asdf-vm/actions/install@v1
+        if: steps.asdf-cache.outputs.cache-hit != 'true'
+        uses: asdf-vm/actions/install@v13
         
       - name: Install rebar
         run: mix local.rebar --force

--- a/.github/workflows/reusable_phoenix_project.yml
+++ b/.github/workflows/reusable_phoenix_project.yml
@@ -46,7 +46,6 @@ jobs:
         uses: asdf-vm/actions/setup@v1
 
       - name: Cache asdf
-        id: asdf-cache
         uses: actions/cache@v2
         with:
           path: |
@@ -56,7 +55,6 @@ jobs:
             ${{ runner.os }}-asdf-
 
       - name: Install dependencies in .tool-versions
-        if: steps.asdf-cache.outputs.cache-hit != 'true'
         uses: asdf-vm/actions/install@v1
         
       - name: Install rebar

--- a/.github/workflows/reusable_phoenix_project.yml
+++ b/.github/workflows/reusable_phoenix_project.yml
@@ -33,12 +33,12 @@ jobs:
           --health-retries 5
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
 
@@ -46,7 +46,7 @@ jobs:
         uses: asdf-vm/actions/setup@v1
 
       - name: Cache asdf
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}

--- a/.github/workflows/reusable_phoenix_project.yml
+++ b/.github/workflows/reusable_phoenix_project.yml
@@ -42,8 +42,14 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Install .tool-versions.
+      - name: Install dependencies in .tool-versions
         uses: asdf-vm/actions/install@v1
+        
+      - name: Install rebar
+        run: mix local.rebar --force
+        
+      - name: Install hex
+        run: mix local.hex --force
         
       - name: Install Phoenix ${{ env.PHOENIX_VERSION }}
         run: make install_phoenix PHOENIX_VERSION=${{ env.PHOENIX_VERSION }}

--- a/.github/workflows/reusable_phoenix_project.yml
+++ b/.github/workflows/reusable_phoenix_project.yml
@@ -11,10 +11,7 @@ on:
         type: string
 
 env:
-  OTP_VERSION: 24.2.2
-  ELIXIR_VERSION: 1.13.3
   PHOENIX_VERSION: 1.6.6
-  NODE_VERSION: 16
   BASE_PROJECT_DIRECTORY: sample_project
   DB_HOST: localhost
   
@@ -45,16 +42,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Set up Elixir ${{ env.ELIXIR_VERSION }} and OTP ${{ env.OTP_VERSION }}
-        uses: erlef/setup-elixir@v1
-        with:
-          otp-version: ${{ env.OTP_VERSION }}
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-
-      - name: Set up Node ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2.1.5
-        with:
-          node-version: ${{ env.NODE_VERSION }}
+      - name: Install .tool-versions.
+        uses: asdf-vm/actions/install@v1
         
       - name: Install Phoenix ${{ env.PHOENIX_VERSION }}
         run: make install_phoenix PHOENIX_VERSION=${{ env.PHOENIX_VERSION }}

--- a/.github/workflows/reusable_phoenix_project.yml
+++ b/.github/workflows/reusable_phoenix_project.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install dependencies in .tool-versions
         if: steps.asdf-cache.outputs.cache-hit != 'true'
-        uses: asdf-vm/actions/install@v13
+        uses: asdf-vm/actions/install@v1
         
       - name: Install rebar
         run: mix local.rebar --force

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -28,11 +28,9 @@ jobs:
       - name: Cache asdf
         uses: actions/cache@v2
         with:
-          path: |
-            /home/runner/.asdf
+          path: /home/runner/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
-          restore-keys: |
-            ${{ runner.os }}-asdf-
+          restore-keys: ${{ runner.os }}-asdf-
       
       - name: Install dependencies in .tool-versions
         uses: asdf-vm/actions/install@v1
@@ -50,8 +48,7 @@ jobs:
             _build
             deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-mix-
+          restore-keys: ${{ runner.os }}-mix-
 
       - name: Install Dependencies
         run: mix deps.get
@@ -83,11 +80,9 @@ jobs:
       - name: Cache asdf
         uses: actions/cache@v2
         with:
-          path: |
-            /home/runner/.asdf
+          path: /home/runner/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
-          restore-keys: |
-            ${{ runner.os }}-asdf-
+          restore-keys: ${{ runner.os }}-asdf-
       
       - name: Install dependencies in .tool-versions
         uses: asdf-vm/actions/install@v1
@@ -105,8 +100,7 @@ jobs:
             _build
             deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-mix-
+          restore-keys: ${{ runner.os }}-mix-
 
       - name: Install Dependencies
         run: mix deps.get
@@ -144,11 +138,9 @@ jobs:
       - name: Cache asdf
         uses: actions/cache@v2
         with:
-          path: |
-            /home/runner/.asdf
+          path: /home/runner/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
-          restore-keys: |
-            ${{ runner.os }}-asdf-
+          restore-keys: ${{ runner.os }}-asdf-
       
       - name: Install dependencies in .tool-versions
         uses: asdf-vm/actions/install@v1
@@ -166,8 +158,7 @@ jobs:
             _build
             deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-mix-
+          restore-keys: ${{ runner.os }}-mix-
 
       - name: Install Dependencies
         run: mix deps.get

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
 
@@ -26,7 +26,7 @@ jobs:
         uses: asdf-vm/actions/setup@v1
       
       - name: Cache asdf
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
@@ -42,7 +42,7 @@ jobs:
         run: mix local.hex --force
 
       - name: Cache Elixir build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             _build
@@ -65,12 +65,12 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
 
@@ -78,7 +78,7 @@ jobs:
         uses: asdf-vm/actions/setup@v1
       
       - name: Cache asdf
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
@@ -94,7 +94,7 @@ jobs:
         run: mix local.hex --force
 
       - name: Cache Elixir build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             _build
@@ -123,12 +123,12 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
 
@@ -136,7 +136,7 @@ jobs:
         uses: asdf-vm/actions/setup@v1
       
       - name: Cache asdf
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
@@ -152,7 +152,7 @@ jobs:
         run: mix local.hex --force
 
       - name: Cache Elixir build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             _build

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -3,8 +3,6 @@ name: Test template
 on: push
 
 env:
-  OTP_VERSION: 24.2.2
-  ELIXIR_VERSION: 1.13.3
   PHOENIX_VERSION: 1.6.6
   MIX_ENV: test
 
@@ -24,11 +22,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Set up Elixir ${{ env.ELIXIR_VERSION }} and OTP ${{ env.OTP_VERSION }}
-        uses: erlef/setup-elixir@v1
-        with:
-          otp-version: ${{ env.OTP_VERSION }}
-          elixir-version: ${{ env.ELIXIR_VERSION }}
+      - name: Install .tool-versions.
+        uses: asdf-vm/actions/install@v1
 
       - name: Cache Elixir build
         uses: actions/cache@v2
@@ -64,11 +59,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Set up Elixir ${{ env.ELIXIR_VERSION }} and OTP ${{ env.OTP_VERSION }}
-        uses: erlef/setup-elixir@v1
-        with:
-          otp-version: ${{ env.OTP_VERSION }}
-          elixir-version: ${{ env.ELIXIR_VERSION }}
+      - name: Install .tool-versions.
+        uses: asdf-vm/actions/install@v1
 
       - name: Cache Elixir build
         uses: actions/cache@v2
@@ -110,11 +102,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Set up Elixir ${{ env.ELIXIR_VERSION }} and OTP ${{ env.OTP_VERSION }}
-        uses: erlef/setup-elixir@v1
-        with:
-          otp-version: ${{ env.OTP_VERSION }}
-          elixir-version: ${{ env.ELIXIR_VERSION }}
+      - name: Install .tool-versions.
+        uses: asdf-vm/actions/install@v1
 
       - name: Cache Elixir build
         uses: actions/cache@v2

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Install .tool-versions.
+      - name: Install dependencies in .tool-versions
         uses: asdf-vm/actions/install@v1
         
       - name: Install rebar
@@ -65,7 +65,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Install .tool-versions.
+      - name: Install dependencies in .tool-versions
         uses: asdf-vm/actions/install@v1
         
       - name: Install rebar
@@ -114,7 +114,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Install .tool-versions.
+      - name: Install dependencies in .tool-versions
         uses: asdf-vm/actions/install@v1
         
       - name: Install rebar

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -22,7 +22,21 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
+      - name: Setup asdf
+        uses: asdf-vm/actions/setup@v1
+      
+      - name: Cache asdf
+        id: asdf-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            /home/runner/.asdf
+          key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
+          restore-keys: |
+            ${{ runner.os }}-asdf-
+      
       - name: Install dependencies in .tool-versions
+        if: steps.asdf-cache.outputs.cache-hit != 'true'
         uses: asdf-vm/actions/install@v1
         
       - name: Install rebar
@@ -65,7 +79,21 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
+      - name: Setup asdf
+        uses: asdf-vm/actions/setup@v1
+      
+      - name: Cache asdf
+        id: asdf-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            /home/runner/.asdf
+          key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
+          restore-keys: |
+            ${{ runner.os }}-asdf-
+      
       - name: Install dependencies in .tool-versions
+        if: steps.asdf-cache.outputs.cache-hit != 'true'
         uses: asdf-vm/actions/install@v1
         
       - name: Install rebar
@@ -114,7 +142,21 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
+      - name: Setup asdf
+        uses: asdf-vm/actions/setup@v1
+      
+      - name: Cache asdf
+        id: asdf-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            /home/runner/.asdf
+          key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
+          restore-keys: |
+            ${{ runner.os }}-asdf-
+      
       - name: Install dependencies in .tool-versions
+        if: steps.asdf-cache.outputs.cache-hit != 'true'
         uses: asdf-vm/actions/install@v1
         
       - name: Install rebar

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -24,6 +24,12 @@ jobs:
 
       - name: Install .tool-versions.
         uses: asdf-vm/actions/install@v1
+        
+      - name: Install rebar
+        run: mix local.rebar --force
+        
+      - name: Install hex
+        run: mix local.hex --force
 
       - name: Cache Elixir build
         uses: actions/cache@v2
@@ -61,6 +67,12 @@ jobs:
 
       - name: Install .tool-versions.
         uses: asdf-vm/actions/install@v1
+        
+      - name: Install rebar
+        run: mix local.rebar --force
+        
+      - name: Install hex
+        run: mix local.hex --force
 
       - name: Cache Elixir build
         uses: actions/cache@v2

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -104,6 +104,9 @@ jobs:
 
       - name: Install .tool-versions.
         uses: asdf-vm/actions/install@v1
+        
+      - name: Install hex
+        run: mix local.hex --force
 
       - name: Cache Elixir build
         uses: actions/cache@v2

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -105,6 +105,9 @@ jobs:
       - name: Install .tool-versions.
         uses: asdf-vm/actions/install@v1
         
+      - name: Install rebar
+        run: mix local.rebar --force
+        
       - name: Install hex
         run: mix local.hex --force
 

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -26,7 +26,6 @@ jobs:
         uses: asdf-vm/actions/setup@v1
       
       - name: Cache asdf
-        id: asdf-cache
         uses: actions/cache@v2
         with:
           path: |
@@ -36,7 +35,6 @@ jobs:
             ${{ runner.os }}-asdf-
       
       - name: Install dependencies in .tool-versions
-        if: steps.asdf-cache.outputs.cache-hit != 'true'
         uses: asdf-vm/actions/install@v1
         
       - name: Install rebar
@@ -83,7 +81,6 @@ jobs:
         uses: asdf-vm/actions/setup@v1
       
       - name: Cache asdf
-        id: asdf-cache
         uses: actions/cache@v2
         with:
           path: |
@@ -93,7 +90,6 @@ jobs:
             ${{ runner.os }}-asdf-
       
       - name: Install dependencies in .tool-versions
-        if: steps.asdf-cache.outputs.cache-hit != 'true'
         uses: asdf-vm/actions/install@v1
         
       - name: Install rebar
@@ -146,7 +142,6 @@ jobs:
         uses: asdf-vm/actions/setup@v1
       
       - name: Cache asdf
-        id: asdf-cache
         uses: actions/cache@v2
         with:
           path: |
@@ -156,7 +151,6 @@ jobs:
             ${{ runner.os }}-asdf-
       
       - name: Install dependencies in .tool-versions
-        if: steps.asdf-cache.outputs.cache-hit != 'true'
         uses: asdf-vm/actions/install@v1
         
       - name: Install rebar

--- a/.github/workflows/verify_release_version.yml
+++ b/.github/workflows/verify_release_version.yml
@@ -31,11 +31,9 @@ jobs:
       - name: Cache asdf
         uses: actions/cache@v2
         with:
-          path: |
-            /home/runner/.asdf
+          path: /home/runner/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
-          restore-keys: |
-            ${{ runner.os }}-asdf-
+          restore-keys: ${{ runner.os }}-asdf-
 
       - name: Install dependencies in .tool-versions
         uses: asdf-vm/actions/install@v1
@@ -53,8 +51,7 @@ jobs:
             _build
             deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-mix-
+          restore-keys: ${{ runner.os }}-mix-
 
       - name: Install Dependencies
         run: mix deps.get

--- a/.github/workflows/verify_release_version.yml
+++ b/.github/workflows/verify_release_version.yml
@@ -6,8 +6,6 @@ on:
       - 'release/**'
 
 env:
-  OTP_VERSION: 23.3
-  ELIXIR_VERSION: 1.11.4
   PHOENIX_VERSION: 1.6.6
   MIX_ENV: test
 
@@ -27,11 +25,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-     - name: Set up Elixir ${{ env.ELIXIR_VERSION }} and OTP ${{ env.OTP_VERSION }}
-       uses: erlef/setup-elixir@v1
-       with:
-         otp-version: ${{ env.OTP_VERSION }}
-         elixir-version: ${{ env.ELIXIR_VERSION }}
+     - name: Install .tool-versions.
+        uses: asdf-vm/actions/install@v1
 
       - name: Cache Elixir build
         uses: actions/cache@v2

--- a/.github/workflows/verify_release_version.yml
+++ b/.github/workflows/verify_release_version.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
 
@@ -29,7 +29,7 @@ jobs:
         uses: asdf-vm/actions/setup@v1
 
       - name: Cache asdf
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
@@ -45,7 +45,7 @@ jobs:
         run: mix local.hex --force
 
       - name: Cache Elixir build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             _build

--- a/.github/workflows/verify_release_version.yml
+++ b/.github/workflows/verify_release_version.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install dependencies in .tool-versions
         if: steps.asdf-cache.outputs.cache-hit != 'true'
-        uses: asdf-vm/actions/install@v13
+        uses: asdf-vm/actions/install@v1
         
       - name: Install rebar
         run: mix local.rebar --force

--- a/.github/workflows/verify_release_version.yml
+++ b/.github/workflows/verify_release_version.yml
@@ -25,8 +25,14 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-     - name: Install .tool-versions.
+      - name: Install dependencies in .tool-versions
         uses: asdf-vm/actions/install@v1
+        
+      - name: Install rebar
+        run: mix local.rebar --force
+        
+      - name: Install hex
+        run: mix local.hex --force
 
       - name: Cache Elixir build
         uses: actions/cache@v2

--- a/.github/workflows/verify_release_version.yml
+++ b/.github/workflows/verify_release_version.yml
@@ -25,8 +25,22 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
+      - name: Setup asdf
+        uses: asdf-vm/actions/setup@v1
+
+      - name: Cache asdf
+        id: asdf-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            /home/runner/.asdf
+          key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
+          restore-keys: |
+            ${{ runner.os }}-asdf-
+
       - name: Install dependencies in .tool-versions
-        uses: asdf-vm/actions/install@v1
+        if: steps.asdf-cache.outputs.cache-hit != 'true'
+        uses: asdf-vm/actions/install@v13
         
       - name: Install rebar
         run: mix local.rebar --force

--- a/.github/workflows/verify_release_version.yml
+++ b/.github/workflows/verify_release_version.yml
@@ -29,7 +29,6 @@ jobs:
         uses: asdf-vm/actions/setup@v1
 
       - name: Cache asdf
-        id: asdf-cache
         uses: actions/cache@v2
         with:
           path: |
@@ -39,7 +38,6 @@ jobs:
             ${{ runner.os }}-asdf-
 
       - name: Install dependencies in .tool-versions
-        if: steps.asdf-cache.outputs.cache-hit != 'true'
         uses: asdf-vm/actions/install@v1
         
       - name: Install rebar

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 erlang 24.2.2
 elixir 1.13.3-otp-24
+nodejs 16.15.0


### PR DESCRIPTION
## What happened

Re-use `.tool-versions` on the CI environment.

## Insight

1/ Just use https://github.com/asdf-vm/actions

2/ For the discussion, please check this [Slack thread](https://nimble-co.slack.com/archives/G4BPLE2DR/p1652858379838899)

This PR is changing only for the Template CLI, to change the `output project` I will open it on the next PR.

## Proof Of Work

The test is passed
