### PR TITLE
Bump to 4.2.1 and Add the bump version helper

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,91 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      newVersion:
+        description: "New version"
+        required: true
+        type: string
+
+env:
+  PHOENIX_VERSION: 1.6.6
+  MIX_ENV: test
+
+jobs:
+  release_version_test:
+    name: Bump version
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Setup asdf
+        uses: asdf-vm/actions/setup@v1
+
+      - name: Cache asdf
+        uses: actions/cache@v3
+        with:
+          path: /home/runner/.asdf
+          key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
+          restore-keys: ${{ runner.os }}-asdf-
+
+      - name: Install dependencies in .tool-versions
+        uses: asdf-vm/actions/install@v1
+
+      - name: Install rebar
+        run: mix local.rebar --force
+
+      - name: Install hex
+        run: mix local.hex --force
+
+      - name: Cache Elixir build
+        uses: actions/cache@v3
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+
+      - name: Install Dependencies
+        run: mix deps.get
+
+      - name: Compile dependencies
+        run: mix compile --warnings-as-errors --all-warnings
+
+      - name: Install Phoenix ${{ env.PHOENIX_VERSION }}
+        run: make install_phoenix PHOENIX_VERSION=${{ env.PHOENIX_VERSION }}
+
+      - name: Bump version
+        run: mix nimble_template.bump_version ${{ github.event.inputs.newVersion }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+          with:
+          token: ${{ secrets.WIKI_ACTION_TOKEN }}
+          commit-message: Bump to ${{ github.event.inputs.newVersion }}
+          committer: Dev Nimble <dev@nimblehq.co>
+          branch: chore/bump-to-${{ github.event.inputs.newVersion }}
+          delete-branch: true
+          title: [Chore] Bump to ${{ github.event.inputs.newVersion }}
+          body: |
+            ## What happened
+
+            Bump to ${{ github.event.inputs.newVersion }}
+
+            ## Insight
+
+            Created by the Bump Version workflow.
+
+            ## Proof Of Work
+
+            Check the file changes

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -87,7 +87,7 @@ jobs:
 
             ## Insight
 
-            Automated creates by the Bump Version workflow.
+            Automatically created by the Bump Version workflow.
 
             ## Proof Of Work
 

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -70,22 +70,25 @@ jobs:
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
-          with:
+        with:
+          assignees: andyduong1920
           token: ${{ secrets.WIKI_ACTION_TOKEN }}
-          commit-message: Bump to ${{ github.event.inputs.newVersion }}
-          committer: Dev Nimble <dev@nimblehq.co>
-          branch: chore/bump-to-${{ github.event.inputs.newVersion }}
+          commit-message: Bump version to ${{ github.event.inputs.newVersion }}
+          committer: Nimble Bot <bot@nimblehq.co>
+          branch: chore/bump-version-to-${{ github.event.inputs.newVersion }}
           delete-branch: true
-          title: [Chore] Bump to ${{ github.event.inputs.newVersion }}
+          title: '[Chore] Bump version to ${{ github.event.inputs.newVersion }}'
+          labels: |
+            type : chore
           body: |
             ## What happened
 
-            Bump to ${{ github.event.inputs.newVersion }}
+            Bump version to ${{ github.event.inputs.newVersion }}
 
             ## Insight
 
-            Created by the Bump Version workflow.
+            Automated creates by the Bump Version workflow.
 
             ## Proof Of Work
 
-            Check the file changes
+            On the Files changed tab

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Step 2: Add `nimble_template` dependency to `mix.exs`:
 ```elixir
 def deps do
   [
-    {:nimble_template, "~> 4.2.0", only: :dev, runtime: false},
+    {:nimble_template, "~> 4.2.1", only: :dev, runtime: false},
     # other dependencies ...
   ]
 end

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Step 2: Add `nimble_template` dependency to `mix.exs`:
 ```elixir
 def deps do
   [
-    {:nimble_template, "~> 4.2", only: :dev, runtime: false},
+    {:nimble_template, "~> 4.2.0", only: :dev, runtime: false},
     # other dependencies ...
   ]
 end
@@ -71,9 +71,17 @@ Set the `HEX_API_KEY` as a Github secret (skip this step if it has been done).
 
 The release process follows the [Git flow](https://nimblehq.co/compass/development/version-control/release-management).
 
-Once a `release/<version number>` is created, to publish the new version to Hex.pm, the version number in the `mix.ex` file needs to be updated on the release branch before merging.
+1. Bump the new version on local
 
-Once the release branch is merged into the `master` branch, Github Action automatically publishes the template to [https://hex.pm/packages/nimble_template](https://hex.pm/packages/nimble_template).
+  ```bash
+  mix nimble_template.bump_version new_version
+  ```
+
+2. Open a PR to develop.
+
+3. Once that bump_version PR is merged, create the `release/<version number>` from the `develop` branch, points to the `master` branch.
+
+4. Once the release branch is merged into the `master` branch, Github Action automatically publishes the template to [https://hex.pm/packages/nimble_template](https://hex.pm/packages/nimble_template).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -65,23 +65,19 @@ mix nimble_template.gen --mix # Apply the Mix template
 
 The testing documentation is on [Wiki](https://github.com/nimblehq/elixir-templates/wiki)
 
-### Release
+### Release process
 
-Set the `HEX_API_KEY` as a Github secret (skip this step if it has been done).
+1. Set the `HEX_API_KEY` as a Github secret (skip this step if it has been done).
 
-The release process follows the [Git flow](https://nimblehq.co/compass/development/version-control/release-management).
+2. Visit the [Bump Version Github Action Workflow](https://github.com/nimblehq/elixir-templates/actions/workflows/bump_version.yml).
 
-1. Bump the new version on local
+3. Trigger the workflow with the next `<version number>`. That workflow will create a PR into the `develop` branch with the title `[Chore] Bump version to <version number>`.
 
-  ```bash
-  mix nimble_template.bump_version new_version
-  ```
+4. Merge the Bump version PR above into the `develop` branch.
 
-2. Open a PR to develop.
+5. Create the `release/<version number>` from the `develop` branch, pointing to the `master` branch.
 
-3. Once that bump_version PR is merged, create the `release/<version number>` from the `develop` branch, points to the `master` branch.
-
-4. Once the release branch is merged into the `master` branch, Github Action automatically publishes the template to [https://hex.pm/packages/nimble_template](https://hex.pm/packages/nimble_template).
+6. Once the release branch is merged into the `master` branch, Github Action automatically publishes the template to [https://hex.pm/packages/nimble_template](https://hex.pm/packages/nimble_template).
 
 ## Contributing
 

--- a/lib/mix/tasks/nimble_template.bump_version.ex
+++ b/lib/mix/tasks/nimble_template.bump_version.ex
@@ -10,7 +10,7 @@ defmodule Mix.Tasks.NimbleTemplate.BumpVersion do
   # Usage
 
   - mix help nimble_template.bump_version # Print help
-  - mix nimble_template.bump_version [new_version] # Bump the template into the [new_version].
+  - mix nimble_template.bump_version [new_version] # Bump the template version to the [new_version].
   """
 
   use Mix.Task

--- a/lib/mix/tasks/nimble_template.bump_version.ex
+++ b/lib/mix/tasks/nimble_template.bump_version.ex
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.NimbleTemplate.BumpVersion do
       {[], [new_version], []} ->
         new_version
 
-      _ ->
+      _other ->
         Mix.raise("Invalid format. Please use `mix nimble_template.bump_version new_version`")
     end
   end

--- a/lib/mix/tasks/nimble_template.bump_version.ex
+++ b/lib/mix/tasks/nimble_template.bump_version.ex
@@ -15,12 +15,12 @@ defmodule Mix.Tasks.NimbleTemplate.BumpVersion do
 
   use Mix.Task
 
-  alias NimbleTemplate.Version
+alias NimbleTemplate.Version
 
   def run(args) do
     new_version = parse_opts(args)
 
-    Version.bump(new_version, %{included_git_action?: true})
+    Version.bump(new_version)
   end
 
   defp parse_opts(args) do

--- a/lib/mix/tasks/nimble_template.bump_version.ex
+++ b/lib/mix/tasks/nimble_template.bump_version.ex
@@ -29,7 +29,9 @@ defmodule Mix.Tasks.NimbleTemplate.BumpVersion do
         new_version
 
       _other ->
-        Mix.raise("Invalid format. Please use `mix nimble_template.bump_version new_version`")
+        Mix.raise(
+          "Invalid command. Check `mix help nimble_template.bump_version` for more information."
+        )
     end
   end
 end

--- a/lib/mix/tasks/nimble_template.bump_version.ex
+++ b/lib/mix/tasks/nimble_template.bump_version.ex
@@ -1,0 +1,35 @@
+defmodule Mix.Tasks.NimbleTemplate.BumpVersion do
+  @shortdoc "Bump the template into specific version."
+
+  @moduledoc """
+  #{@shortdoc}
+
+  - Hex package: https://hex.pm/packages/nimble_template
+  - Github: https://github.com/nimblehq/elixir-templates
+
+  # Usage
+
+  - mix help nimble_template.bump_version # Print help
+  - mix nimble_template.bump_version [new_version] # Bump the template into the [new_version].
+  """
+
+  use Mix.Task
+
+  alias NimbleTemplate.Version
+
+  def run(args) do
+    new_version = parse_opts(args)
+
+    Version.bump(new_version, %{included_git_action?: true})
+  end
+
+  defp parse_opts(args) do
+    case OptionParser.parse(args, strict: []) do
+      {[], [new_version], []} ->
+        new_version
+
+      _ ->
+        Mix.raise("Invalid format. Please use `mix nimble_template.bump_version new_version`")
+    end
+  end
+end

--- a/lib/mix/tasks/nimble_template.bump_version.ex
+++ b/lib/mix/tasks/nimble_template.bump_version.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.NimbleTemplate.BumpVersion do
 
   use Mix.Task
 
-alias NimbleTemplate.Version
+  alias NimbleTemplate.Version
 
   def run(args) do
     new_version = parse_opts(args)

--- a/lib/nimble_template/version.ex
+++ b/lib/nimble_template/version.ex
@@ -48,5 +48,7 @@ defmodule NimbleTemplate.Version do
   defp git_add_and_push(new_version) do
     Mix.shell().cmd("git add mix.exs README.md")
     Mix.shell().cmd("git commit -m \"Bump to #{new_version}\"")
+
+    Mix.shell().cmd("git push origin chore/bump-to-#{new_version} -f")
   end
 end

--- a/lib/nimble_template/version.ex
+++ b/lib/nimble_template/version.ex
@@ -24,7 +24,7 @@ defmodule NimbleTemplate.Version do
   end
 
   defp included_git_action?(%{included_git_action?: true}), do: true
-  defp included_git_action?(_), do: false
+  defp included_git_action?(_opts), do: false
 
   defp bump_version_to(current_version, new_version) do
     Generator.replace_content(

--- a/lib/nimble_template/version.ex
+++ b/lib/nimble_template/version.ex
@@ -3,28 +3,17 @@ defmodule NimbleTemplate.Version do
 
   alias NimbleTemplate.Generator
 
-  def bump(new_version, opts \\ %{}) do
+  def bump(new_version) do
     current_version = Mix.Project.config()[:version]
 
     if new_version > current_version do
-      if included_git_action?(opts) do
-        git_checkout_chore_branch(new_version)
-      end
-
       bump_version_to(current_version, new_version)
-
-      if included_git_action?(opts) do
-        git_add_and_push(new_version)
-      end
 
       :ok
     else
       Mix.raise("The new version must be greater than #{current_version}")
     end
   end
-
-  defp included_git_action?(%{included_git_action?: true}), do: true
-  defp included_git_action?(_opts), do: false
 
   defp bump_version_to(current_version, new_version) do
     Generator.replace_content(
@@ -38,17 +27,5 @@ defmodule NimbleTemplate.Version do
       "{:nimble_template, \"~> #{current_version}\", only: :dev, runtime: false},",
       "{:nimble_template, \"~> #{new_version}\", only: :dev, runtime: false},"
     )
-  end
-
-  defp git_checkout_chore_branch(new_version) do
-    Mix.shell().cmd("git checkout develop")
-    Mix.shell().cmd("git checkout -b chore/bump-to-#{new_version}")
-  end
-
-  defp git_add_and_push(new_version) do
-    Mix.shell().cmd("git add mix.exs README.md")
-    Mix.shell().cmd("git commit -m \"Bump to #{new_version}\"")
-
-    Mix.shell().cmd("git push origin chore/bump-to-#{new_version} -f")
   end
 end

--- a/lib/nimble_template/version.ex
+++ b/lib/nimble_template/version.ex
@@ -1,0 +1,52 @@
+defmodule NimbleTemplate.Version do
+  @moduledoc false
+
+  alias NimbleTemplate.Generator
+
+  def bump(new_version, opts \\ %{}) do
+    current_version = Mix.Project.config()[:version]
+
+    if new_version > current_version do
+      if included_git_action?(opts) do
+        git_checkout_chore_branch(new_version)
+      end
+
+      bump_version_to(current_version, new_version)
+
+      if included_git_action?(opts) do
+        git_add_and_push(new_version)
+      end
+
+      :ok
+    else
+      Mix.raise("The new version must be greater than #{current_version}")
+    end
+  end
+
+  defp included_git_action?(%{included_git_action?: true}), do: true
+  defp included_git_action?(_), do: false
+
+  defp bump_version_to(current_version, new_version) do
+    Generator.replace_content(
+      "mix.exs",
+      "version: \"#{current_version}\",",
+      "version: \"#{new_version}\","
+    )
+
+    Generator.replace_content(
+      "README.md",
+      "{:nimble_template, \"~> #{current_version}\", only: :dev, runtime: false},",
+      "{:nimble_template, \"~> #{new_version}\", only: :dev, runtime: false},"
+    )
+  end
+
+  defp git_checkout_chore_branch(new_version) do
+    Mix.shell().cmd("git checkout develop")
+    Mix.shell().cmd("git checkout -b chore/bump-to-#{new_version}")
+  end
+
+  defp git_add_and_push(new_version) do
+    Mix.shell().cmd("git add mix.exs README.md")
+    Mix.shell().cmd("git commit -m \"Bump to #{new_version}\"")
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule NimbleTemplate.MixProject do
   def project do
     [
       app: :nimble_template,
-      version: "4.2.0",
+      version: "4.2.1",
       description: "Phoenix/Mix template for projects at [Nimble](https://nimblehq.co/).",
       elixir: "~> 1.13.3",
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/test/nimble_template/version_test.exs
+++ b/test/nimble_template/version_test.exs
@@ -1,0 +1,63 @@
+defmodule NimbleTemplate.VersionTest do
+  use NimbleTemplate.AddonCase, async: false
+
+  alias NimbleTemplate.Version
+
+  describe "bump/1" do
+    test "updates the version in mix.exs and README.md files given a valid version number" do
+      current_version = Mix.Project.config()[:version]
+
+      patch_number =
+        current_version
+        |> String.split(".")
+        |> List.last()
+        |> String.to_integer()
+
+      # Increase the patch version to 1
+      new_version =
+        current_version
+        |> String.split(".")
+        |> List.replace_at(2, patch_number + 1)
+        |> Enum.join(".")
+
+      assert Version.bump(new_version) == :ok
+
+      assert_file("mix.exs", fn file ->
+        assert file =~ "version: \"#{new_version}\""
+      end)
+
+      assert_file("README.md", fn file ->
+        assert file =~ "{:nimble_template, \"~> #{new_version}\", only: :dev, runtime: false},"
+      end)
+    end
+
+    test "raises Mix.Error exception given an invalid version number" do
+      current_version = Mix.Project.config()[:version]
+
+      major_number =
+        current_version
+        |> String.split(".")
+        |> List.first()
+        |> String.to_integer()
+
+      # Decrease the major version to 1
+      new_version =
+        current_version
+        |> String.split(".")
+        |> List.replace_at(0, major_number - 1)
+        |> Enum.join(".")
+
+      assert_raise Mix.Error, "The new version must be greater than #{current_version}", fn ->
+        Version.bump(new_version)
+      end
+
+      assert_file("mix.exs", fn file ->
+        assert file =~ "version: \"#{current_version}\""
+      end)
+
+      assert_file("README.md", fn file ->
+        assert file =~ "{:nimble_template, \"~> #{current_version}\", only: :dev, runtime: false},"
+      end)
+    end
+  end
+end

--- a/test/nimble_template/version_test.exs
+++ b/test/nimble_template/version_test.exs
@@ -3,6 +3,12 @@ defmodule NimbleTemplate.VersionTest do
 
   alias NimbleTemplate.Version
 
+  setup do
+    on_exit(fn ->
+      Mix.shell().cmd("git checkout mix.exs README.md")
+    end)
+  end
+
   describe "bump/1" do
     test "updates the version in mix.exs and README.md files given a valid version number" do
       current_version = Mix.Project.config()[:version]
@@ -24,10 +30,12 @@ defmodule NimbleTemplate.VersionTest do
 
       assert_file("mix.exs", fn file ->
         assert file =~ "version: \"#{new_version}\""
+        refute file =~ "version: \"#{current_version}\""
       end)
 
       assert_file("README.md", fn file ->
         assert file =~ "{:nimble_template, \"~> #{new_version}\", only: :dev, runtime: false},"
+        refute file =~ "{:nimble_template, \"~> #{current_version}\", only: :dev, runtime: false},"
       end)
     end
 
@@ -52,10 +60,12 @@ defmodule NimbleTemplate.VersionTest do
       end
 
       assert_file("mix.exs", fn file ->
+        assert file =~ "version: \"#{current_version}\""
         refute file =~ "version: \"#{new_version}\""
       end)
 
       assert_file("README.md", fn file ->
+        assert file =~ "{:nimble_template, \"~> #{current_version}\", only: :dev, runtime: false},"
         refute file =~ "{:nimble_template, \"~> #{new_version}\", only: :dev, runtime: false},"
       end)
     end

--- a/test/nimble_template/version_test.exs
+++ b/test/nimble_template/version_test.exs
@@ -52,11 +52,11 @@ defmodule NimbleTemplate.VersionTest do
       end
 
       assert_file("mix.exs", fn file ->
-        assert file =~ "version: \"#{current_version}\""
+        refute file =~ "version: \"#{new_version}\""
       end)
 
       assert_file("README.md", fn file ->
-        assert file =~ "{:nimble_template, \"~> #{current_version}\", only: :dev, runtime: false},"
+        refute file =~ "{:nimble_template, \"~> #{new_version}\", only: :dev, runtime: false},"
       end)
     end
   end


### PR DESCRIPTION
## What happened

As the `bump version` step is kind of similar on each release. Creating a task for it.

## Insight

1. Create 1 Elixir module
2. Create 1 Elixir task
3. Run it with `mix nimble_template.bump_version xxx`

## Proof Of Work

### I/ The Elixir module

1/ 
The test is passed

2/ mix help nimble_template.bump_version
![image](https://user-images.githubusercontent.com/11751745/172351036-638ab322-15cf-484e-9378-7496cf761a61.png)

3/ Test the task
![image](https://user-images.githubusercontent.com/11751745/172350338-e1a59fb4-6945-4825-86ee-a9883f858b86.png)

4/ Invalid format

![image](https://user-images.githubusercontent.com/11751745/172351294-fb337258-b41a-4490-ba9a-ba2804e60b22.png)

### II/ Github Action

1/ Invalid case

![image](https://user-images.githubusercontent.com/11751745/172517939-17fde5cc-fa53-4769-ae4e-3da908a1fc26.png)


2/ Valid case

![image](https://user-images.githubusercontent.com/11751745/172519329-18c7147e-940c-4796-b987-60acff1f0ed8.png)

The demo PR: https://github.com/nimblehq/elixir-templates/pull/224