### PR TITLE
Add the VersionUpgradeHelper

### DIFF
--- a/lib/nimble_template/helpers/generator.ex
+++ b/lib/nimble_template/helpers/generator.ex
@@ -24,7 +24,7 @@ defmodule NimbleTemplate.Generator do
 
   def rename_file(old_path, new_path), do: File.rename(old_path, new_path)
 
-  def replace_content(file_path, anchor, content) do
+  def replace_content(file_path, anchor, content, raise_exception \\ true) do
     file = Path.join([file_path])
 
     file_content =
@@ -40,7 +40,21 @@ defmodule NimbleTemplate.Generator do
         File.write!(file, [left, content, right])
 
       :error ->
-        Mix.raise(~s[Could not find #{anchor} in #{file_path}])
+        if raise_exception do
+          Mix.raise(~s[Could not find #{anchor} in #{file_path}])
+        else
+          :error
+        end
+    end
+  end
+
+  def replace_content_all(file_path, anchor, content) do
+    case replace_content(file_path, anchor, content, false) do
+      :ok ->
+        replace_content_all(file_path, anchor, content)
+
+      :error ->
+        nil
     end
   end
 

--- a/lib/nimble_template/projects/project.ex
+++ b/lib/nimble_template/projects/project.ex
@@ -16,10 +16,9 @@ defmodule NimbleTemplate.Projects.Project do
             # Dependency Versions
             alpine_version: @alpine_version,
             elixir_version: @elixir_version,
-            elixir_asdf_version:
-              "#{@elixir_version}-otp-#{@erlang_version |> String.split(".") |> List.first()}",
             erlang_version: @erlang_version,
             node_asdf_version: @node_asdf_version,
+            elixir_asdf_version: nil,
             # Variants
             api_project?: false,
             live_project?: false,
@@ -38,8 +37,23 @@ defmodule NimbleTemplate.Projects.Project do
       api_project?: api_project?(opts),
       web_project?: web_project?(opts),
       live_project?: live_project?(opts),
-      mix_project?: mix_project?(opts)
+      mix_project?: mix_project?(opts),
+      elixir_asdf_version: "#{@elixir_version}-otp-#{get_otp_major_version(@erlang_version)}"
     }
+  end
+
+  def alpine_version, do: @alpine_version
+
+  def elixir_version, do: @elixir_version
+
+  def erlang_version, do: @erlang_version
+
+  def node_asdf_version, do: @node_asdf_version
+
+  def get_otp_major_version(erlang_version) do
+    erlang_version
+    |> String.split(".")
+    |> List.first()
   end
 
   defp api_project?(opts), do: opts[:api] === true

--- a/lib/nimble_template/version.ex
+++ b/lib/nimble_template/version.ex
@@ -64,6 +64,12 @@ defmodule NimbleTemplate.Version do
       "@elixir_version \"#{new_version}\""
     )
 
+    Generator.replace_content(
+      ".tool-versions",
+      "elixir #{current_version}",
+      "elixir #{new_version}"
+    )
+
     Generator.replace_content_all(
       "test/nimble_template/addons/asdf_tool_version_test.exs",
       "elixir #{current_version}-otp-#{}",
@@ -96,6 +102,18 @@ defmodule NimbleTemplate.Version do
       "lib/nimble_template/projects/project.ex",
       "@erlang_version \"#{current_version}\"",
       "@erlang_version \"#{new_version}\""
+    )
+
+    Generator.replace_content(
+      ".tool-versions",
+      "erlang #{current_version}",
+      "erlang #{new_version}"
+    )
+
+    Generator.replace_content(
+      ".tool-versions",
+      "-otp-#{Project.get_otp_major_version(current_version)}",
+      "-otp-#{Project.get_otp_major_version(new_version)}"
     )
 
     Generator.replace_content_all(
@@ -152,6 +170,12 @@ defmodule NimbleTemplate.Version do
       "lib/nimble_template/projects/project.ex",
       "@node_asdf_version \"#{current_version}\"",
       "@node_asdf_version \"#{new_version}\""
+    )
+
+    Generator.replace_content(
+      ".tool-versions",
+      "nodejs #{current_version}",
+      "nodejs #{new_version}"
     )
 
     Generator.replace_content_all(

--- a/lib/nimble_template/version.ex
+++ b/lib/nimble_template/version.ex
@@ -2,6 +2,7 @@ defmodule NimbleTemplate.Version do
   @moduledoc false
 
   alias NimbleTemplate.Generator
+  alias NimbleTemplate.Projects.Project
 
   def bump(new_version) do
     current_version = Mix.Project.config()[:version]
@@ -15,6 +16,31 @@ defmodule NimbleTemplate.Version do
     end
   end
 
+  def upgrade_elixir_erlang_node_and_alpine(versions) do
+    elixir_version = Map.get(versions, :elixir_version, nil)
+    erlang_version = Map.get(versions, :erlang_version, nil)
+    node_version = Map.get(versions, :node_version, nil)
+    alpine_version = Map.get(versions, :alpine_version, nil)
+
+    if elixir_version do
+      upgrade_elixir(elixir_version)
+    end
+
+    if erlang_version do
+      upgrade_erlang(erlang_version)
+    end
+
+    if alpine_version do
+      upgrade_alpine(alpine_version)
+    end
+
+    if node_version do
+      upgrade_node(node_version)
+    end
+
+    :ok
+  end
+
   defp bump_version_to(current_version, new_version) do
     Generator.replace_content(
       "mix.exs",
@@ -26,6 +52,124 @@ defmodule NimbleTemplate.Version do
       "README.md",
       "{:nimble_template, \"~> #{current_version}\", only: :dev, runtime: false},",
       "{:nimble_template, \"~> #{new_version}\", only: :dev, runtime: false},"
+    )
+  end
+
+  defp upgrade_elixir(new_version) do
+    current_version = Project.elixir_version()
+
+    Generator.replace_content(
+      "lib/nimble_template/projects/project.ex",
+      "@elixir_version \"#{current_version}\"",
+      "@elixir_version \"#{new_version}\""
+    )
+
+    Generator.replace_content_all(
+      "test/nimble_template/addons/asdf_tool_version_test.exs",
+      "elixir #{current_version}-otp-#{}",
+      "elixir #{new_version}-otp-#{}"
+    )
+
+    Generator.replace_content_all(
+      "test/nimble_template/addons/github_test.exs",
+      "Elixir #{current_version}",
+      "Elixir #{new_version}"
+    )
+
+    Generator.replace_content_all(
+      "test/nimble_template/addons/readme_test.exs",
+      "Elixir #{current_version}",
+      "Elixir #{new_version}"
+    )
+
+    Generator.replace_content(
+      "test/nimble_template/addons/variants/docker_test.exs",
+      "ELIXIR_IMAGE_VERSION=#{current_version}",
+      "ELIXIR_IMAGE_VERSION=#{new_version}"
+    )
+  end
+
+  defp upgrade_erlang(new_version) do
+    current_version = Project.erlang_version()
+
+    Generator.replace_content(
+      "lib/nimble_template/projects/project.ex",
+      "@erlang_version \"#{current_version}\"",
+      "@erlang_version \"#{new_version}\""
+    )
+
+    Generator.replace_content_all(
+      "test/nimble_template/addons/asdf_tool_version_test.exs",
+      "erlang #{current_version}",
+      "erlang #{new_version}"
+    )
+
+    Generator.replace_content_all(
+      "test/nimble_template/addons/asdf_tool_version_test.exs",
+      "-otp-#{Project.get_otp_major_version(current_version)}",
+      "-otp-#{Project.get_otp_major_version(new_version)}"
+    )
+
+    Generator.replace_content_all(
+      "test/nimble_template/addons/github_test.exs",
+      "Erlang #{current_version}",
+      "Erlang #{new_version}"
+    )
+
+    Generator.replace_content_all(
+      "test/nimble_template/addons/readme_test.exs",
+      "Erlang #{current_version}",
+      "Erlang #{new_version}"
+    )
+
+    Generator.replace_content(
+      "test/nimble_template/addons/variants/docker_test.exs",
+      "ERLANG_IMAGE_VERSION=#{current_version}",
+      "ERLANG_IMAGE_VERSION=#{new_version}"
+    )
+  end
+
+  defp upgrade_alpine(new_version) do
+    current_version = Project.alpine_version()
+
+    Generator.replace_content(
+      "lib/nimble_template/projects/project.ex",
+      "@alpine_version \"#{current_version}\"",
+      "@alpine_version \"#{new_version}\""
+    )
+
+    Generator.replace_content(
+      "test/nimble_template/addons/variants/docker_test.exs",
+      "RELEASE_IMAGE_VERSION=#{current_version}",
+      "RELEASE_IMAGE_VERSION=#{new_version}"
+    )
+  end
+
+  defp upgrade_node(new_version) do
+    current_version = Project.node_asdf_version()
+
+    Generator.replace_content(
+      "lib/nimble_template/projects/project.ex",
+      "@node_asdf_version \"#{current_version}\"",
+      "@node_asdf_version \"#{new_version}\""
+    )
+
+    Generator.replace_content_all(
+      "test/nimble_template/addons/asdf_tool_version_test.exs",
+      "nodejs #{current_version}",
+      "nodejs #{new_version}"
+    )
+
+    Generator.replace_content_all(
+      "test/nimble_template/addons/github_test.exs",
+      "Node #{current_version}",
+      "Node #{new_version}"
+    )
+
+    Generator.replace_content_all(
+      "test/nimble_template/addons/readme_test.exs",
+      "Node #{current_version}",
+      "Node #{new_version}"
     )
   end
 end

--- a/lib/nimble_template/version.ex
+++ b/lib/nimble_template/version.ex
@@ -16,11 +16,11 @@ defmodule NimbleTemplate.Version do
     end
   end
 
-  def upgrade_elixir_erlang_node_and_alpine(versions) do
-    elixir_version = Map.get(versions, :elixir_version, nil)
-    erlang_version = Map.get(versions, :erlang_version, nil)
-    node_version = Map.get(versions, :node_version, nil)
-    alpine_version = Map.get(versions, :alpine_version, nil)
+  def upgrade_stack(elixir_erlang_node_alpine_versions) do
+    elixir_version = Map.get(elixir_erlang_node_alpine_versions, :elixir_version, nil)
+    erlang_version = Map.get(elixir_erlang_node_alpine_versions, :erlang_version, nil)
+    node_version = Map.get(elixir_erlang_node_alpine_versions, :node_version, nil)
+    alpine_version = Map.get(elixir_erlang_node_alpine_versions, :alpine_version, nil)
 
     if elixir_version do
       upgrade_elixir(elixir_version)

--- a/test/nimble_template/version_test.exs
+++ b/test/nimble_template/version_test.exs
@@ -5,7 +5,7 @@ defmodule NimbleTemplate.VersionTest do
 
   setup do
     on_exit(fn ->
-      Mix.shell().cmd("git checkout mix.exs README.md")
+      Mix.shell().cmd("git checkout .")
     end)
   end
 
@@ -67,6 +67,89 @@ defmodule NimbleTemplate.VersionTest do
       assert_file("README.md", fn file ->
         assert file =~ "{:nimble_template, \"~> #{current_version}\", only: :dev, runtime: false},"
         refute file =~ "{:nimble_template, \"~> #{new_version}\", only: :dev, runtime: false},"
+      end)
+    end
+  end
+
+  describe "upgrade_elixir_erlang_node_and_alpine/1" do
+    test "upgrade elixir version given the new elixir_version" do
+      assert Version.upgrade_elixir_erlang_node_and_alpine(%{elixir_version: "130.13.4"}) == :ok
+
+      assert_file("lib/nimble_template/projects/project.ex", fn file ->
+        assert file =~ "@elixir_version \"130.13.4\""
+      end)
+
+      assert_file("test/nimble_template/addons/asdf_tool_version_test.exs", fn file ->
+        assert file =~ "elixir 130.13.4-otp-"
+      end)
+
+      assert_file("test/nimble_template/addons/github_test.exs", fn file ->
+        assert file =~ "Elixir 130.13.4"
+      end)
+
+      assert_file("test/nimble_template/addons/readme_test.exs", fn file ->
+        assert file =~ "Elixir 130.13.4"
+      end)
+
+      assert_file("test/nimble_template/addons/variants/docker_test.exs", fn file ->
+        assert file =~ "ELIXIR_IMAGE_VERSION=130.13.4"
+      end)
+    end
+
+    test "upgrade erlang version given the new erlang_version" do
+      assert Version.upgrade_elixir_erlang_node_and_alpine(%{erlang_version: "250.0.1"}) == :ok
+
+      assert_file("lib/nimble_template/projects/project.ex", fn file ->
+        assert file =~ "@erlang_version \"250.0.1\""
+      end)
+
+      assert_file("test/nimble_template/addons/asdf_tool_version_test.exs", fn file ->
+        assert file =~ "erlang 250.0.1"
+        assert file =~ "-otp-250"
+      end)
+
+      assert_file("test/nimble_template/addons/github_test.exs", fn file ->
+        assert file =~ "Erlang 250.0.1"
+      end)
+
+      assert_file("test/nimble_template/addons/readme_test.exs", fn file ->
+        assert file =~ "Erlang 250.0.1"
+      end)
+
+      assert_file("test/nimble_template/addons/variants/docker_test.exs", fn file ->
+        assert file =~ "ERLANG_IMAGE_VERSION=250.0.1"
+      end)
+    end
+
+    test "upgrade node version given the new node_version" do
+      assert Version.upgrade_elixir_erlang_node_and_alpine(%{node_version: "180.3.0"}) == :ok
+
+      assert_file("lib/nimble_template/projects/project.ex", fn file ->
+        assert file =~ "@node_asdf_version \"180.3.0\""
+      end)
+
+      assert_file("test/nimble_template/addons/asdf_tool_version_test.exs", fn file ->
+        assert file =~ "nodejs 180.3.0"
+      end)
+
+      assert_file("test/nimble_template/addons/github_test.exs", fn file ->
+        assert file =~ "Node 180.3.0"
+      end)
+
+      assert_file("test/nimble_template/addons/readme_test.exs", fn file ->
+        assert file =~ "Node 180.3.0"
+      end)
+    end
+
+    test "upgrade alpine version given the new alpine_version" do
+      assert Version.upgrade_elixir_erlang_node_and_alpine(%{alpine_version: "300.14.6"}) == :ok
+
+      assert_file("lib/nimble_template/projects/project.ex", fn file ->
+        assert file =~ "@alpine_version \"300.14.6\""
+      end)
+
+      assert_file("test/nimble_template/addons/variants/docker_test.exs", fn file ->
+        assert file =~ "RELEASE_IMAGE_VERSION=300.14.6"
       end)
     end
   end

--- a/test/nimble_template/version_test.exs
+++ b/test/nimble_template/version_test.exs
@@ -71,9 +71,9 @@ defmodule NimbleTemplate.VersionTest do
     end
   end
 
-  describe "upgrade_elixir_erlang_node_and_alpine/1" do
+  describe "upgrade_stack/1" do
     test "upgrade elixir version given the new elixir_version" do
-      assert Version.upgrade_elixir_erlang_node_and_alpine(%{elixir_version: "130.13.4"}) == :ok
+      assert Version.upgrade_stack(%{elixir_version: "130.13.4"}) == :ok
 
       assert_file("lib/nimble_template/projects/project.ex", fn file ->
         assert file =~ "@elixir_version \"130.13.4\""
@@ -101,7 +101,7 @@ defmodule NimbleTemplate.VersionTest do
     end
 
     test "upgrade erlang version given the new erlang_version" do
-      assert Version.upgrade_elixir_erlang_node_and_alpine(%{erlang_version: "250.0.1"}) == :ok
+      assert Version.upgrade_stack(%{erlang_version: "250.0.1"}) == :ok
 
       assert_file("lib/nimble_template/projects/project.ex", fn file ->
         assert file =~ "@erlang_version \"250.0.1\""
@@ -131,7 +131,7 @@ defmodule NimbleTemplate.VersionTest do
     end
 
     test "upgrade node version given the new node_version" do
-      assert Version.upgrade_elixir_erlang_node_and_alpine(%{node_version: "180.3.0"}) == :ok
+      assert Version.upgrade_stack(%{node_version: "180.3.0"}) == :ok
 
       assert_file("lib/nimble_template/projects/project.ex", fn file ->
         assert file =~ "@node_asdf_version \"180.3.0\""
@@ -155,7 +155,7 @@ defmodule NimbleTemplate.VersionTest do
     end
 
     test "upgrade alpine version given the new alpine_version" do
-      assert Version.upgrade_elixir_erlang_node_and_alpine(%{alpine_version: "300.14.6"}) == :ok
+      assert Version.upgrade_stack(%{alpine_version: "300.14.6"}) == :ok
 
       assert_file("lib/nimble_template/projects/project.ex", fn file ->
         assert file =~ "@alpine_version \"300.14.6\""

--- a/test/nimble_template/version_test.exs
+++ b/test/nimble_template/version_test.exs
@@ -79,6 +79,10 @@ defmodule NimbleTemplate.VersionTest do
         assert file =~ "@elixir_version \"130.13.4\""
       end)
 
+      assert_file(".tool-versions", fn file ->
+        assert file =~ "elixir 130.13.4-otp-"
+      end)
+
       assert_file("test/nimble_template/addons/asdf_tool_version_test.exs", fn file ->
         assert file =~ "elixir 130.13.4-otp-"
       end)
@@ -101,6 +105,11 @@ defmodule NimbleTemplate.VersionTest do
 
       assert_file("lib/nimble_template/projects/project.ex", fn file ->
         assert file =~ "@erlang_version \"250.0.1\""
+      end)
+
+      assert_file(".tool-versions", fn file ->
+        assert file =~ "erlang 250.0.1"
+        assert file =~ "-otp-250"
       end)
 
       assert_file("test/nimble_template/addons/asdf_tool_version_test.exs", fn file ->
@@ -126,6 +135,10 @@ defmodule NimbleTemplate.VersionTest do
 
       assert_file("lib/nimble_template/projects/project.ex", fn file ->
         assert file =~ "@node_asdf_version \"180.3.0\""
+      end)
+
+      assert_file(".tool-versions", fn file ->
+        assert file =~ "nodejs 180.3.0"
       end)
 
       assert_file("test/nimble_template/addons/asdf_tool_version_test.exs", fn file ->


### PR DESCRIPTION
## What happened

As we upgrade the version frequently, the process is quite boring, I have created a helper for that, so we just need to run that method and everything will be done.

The next step will be:

- Create the Github Action which receives up to 4 inputs (elixir, erlang, node, alpine version)
- That Github Action will upgrade the version similar to the [Bump Version](https://github.com/nimblehq/elixir-templates/blob/develop/.github/workflows/bump_version.yml)
- That Github Action will create a PR to upgrade those versions automatically, similar to the [Bump Version PR](https://github.com/nimblehq/elixir-templates/pull/227)
- Also the next step we will create a cronjob task on Github Action to fetch the latest Elixir, Erlang. Node and Alpine versions, run this task and create a PR automatically 🤞

## Insight

Add the `upgrade_elixir_erlang_node_and_alpine` in the Version module

## Proof Of Work

The test is passed

The command is used to generate the https://github.com/nimblehq/elixir-templates/pull/229

![image](https://user-images.githubusercontent.com/11751745/172829725-84b714fb-1898-4f85-8b56-5c266f177fb5.png)


