### PR TITLE
[gh-240] Add html_filter_full_covered option to excoveralls

### DIFF
--- a/lib/nimble_template/addons/ex_coveralls.ex
+++ b/lib/nimble_template/addons/ex_coveralls.ex
@@ -13,7 +13,8 @@ defmodule NimbleTemplate.Addons.ExCoveralls do
   defp copy_files(%Project{otp_app: otp_app, mix_project?: mix_project?} = project) do
     binding = [
       otp_app: otp_app,
-      minimum_coverage: 100
+      minimum_coverage: 100,
+      html_filter_full_covered: true
     ]
 
     template_file_path =

--- a/priv/templates/nimble_template/coveralls.json.eex
+++ b/priv/templates/nimble_template/coveralls.json.eex
@@ -13,6 +13,7 @@
     "test/support"
   ],
   "coverage_options": {
-    "minimum_coverage": <%= minimum_coverage %>
+    "minimum_coverage": <%= minimum_coverage %>,
+    "html_filter_full_covered": <%= html_filter_full_covered %>
   }
 }

--- a/priv/templates/nimble_template/coveralls.json.mix.eex
+++ b/priv/templates/nimble_template/coveralls.json.mix.eex
@@ -4,6 +4,7 @@
     "test/support"
   ],
   "coverage_options": {
-    "minimum_coverage": <%= minimum_coverage %>
+    "minimum_coverage": <%= minimum_coverage %>,
+    "html_filter_full_covered": <%= html_filter_full_covered %>,
   }
 }

--- a/test/nimble_template/addons/ex_coveralls_test.exs
+++ b/test/nimble_template/addons/ex_coveralls_test.exs
@@ -12,8 +12,8 @@ defmodule NimbleTemplate.Addons.ExCoverallsTest do
         Addons.ExCoveralls.apply(project)
 
         assert_file("coveralls.json", fn file ->
-          assert file =~ "minimum_coverage: 100"
-          assert file =~ "html_filter_full_covered: true"
+          assert file =~ "minimum_coverage\": 100"
+          assert file =~ "html_filter_full_covered\": true"
         end)
       end)
     end

--- a/test/nimble_template/addons/ex_coveralls_test.exs
+++ b/test/nimble_template/addons/ex_coveralls_test.exs
@@ -11,7 +11,10 @@ defmodule NimbleTemplate.Addons.ExCoverallsTest do
       in_test_project(test_project_path, fn ->
         Addons.ExCoveralls.apply(project)
 
-        assert_file("coveralls.json")
+        assert_file("coveralls.json", fn file ->
+          assert file =~ "minimum_coverage: 100"
+          assert file =~ "html_filter_full_covered: true"
+        end)
       end)
     end
 


### PR DESCRIPTION
Close https://github.com/nimblehq/elixir-templates/issues/240

## What happened 👀

`html_filter_full_covered` option will neglect 100% coverage files won't be displayed in the HTML report.

## Insight 📝

- Add `html_filter_full_covered` option to `coveralls.json` file.
- Some 0% files (aligning with coveralls.io behavior) still persist with the coverage HTML report.

## Proof Of Work 📹
Before:
![image](https://user-images.githubusercontent.com/42540264/184321443-6dec49fd-c610-43db-9abf-e667fd9b189b.png)

After:
![image](https://user-images.githubusercontent.com/42540264/184321673-7db496d3-6c1d-41ed-840a-cba3c99a7eaa.png)


