### PR TITLE
[#252][Chore] Resolve the Gettext warning in config

### DIFF
--- a/lib/nimble_template/templates/variants/phoenix/template.ex
+++ b/lib/nimble_template/templates/variants/phoenix/template.ex
@@ -19,7 +19,7 @@ defmodule NimbleTemplate.Templates.Phoenix.Template do
   # credo:disable-for-next-line Credo.Check.Refactor.ABCSize
   defp apply_phoenix_common_setup(%Project{} = project) do
     # TODO: Remove me after the Phoenix generator fix releases: https://github.com/phoenixframework/phoenix/pull/4894
-    remove_gettext_compiler()
+    remove_mix_compiler_config()
 
     project
     |> apply_default_common_phoenix_addons()
@@ -112,7 +112,7 @@ defmodule NimbleTemplate.Templates.Phoenix.Template do
   defp apply_phoenix_variant_setup(%Project{web_project?: true, live_project?: true} = project),
     do: LiveTemplate.apply(project)
 
-  defp remove_gettext_compiler() do
-    Generator.delete_content("mix.exs", "[:gettext] ++ ")
+  defp remove_mix_compiler_config() do
+    Generator.delete_content("mix.exs", "compilers: [:gettext] ++ Mix.compilers(),")
   end
 end

--- a/lib/nimble_template/templates/variants/phoenix/template.ex
+++ b/lib/nimble_template/templates/variants/phoenix/template.ex
@@ -3,7 +3,7 @@ defmodule NimbleTemplate.Templates.Phoenix.Template do
 
   import NimbleTemplate.{AddonHelper, GithubHelper}
 
-  alias NimbleTemplate.Addons
+  alias NimbleTemplate.{Addons, Generator}
   alias NimbleTemplate.Addons.Phoenix, as: PhoenixAddons
   alias NimbleTemplate.Projects.Project
   alias NimbleTemplate.Templates.Phoenix.Api.Template, as: ApiTemplate
@@ -18,6 +18,9 @@ defmodule NimbleTemplate.Templates.Phoenix.Template do
 
   # credo:disable-for-next-line Credo.Check.Refactor.ABCSize
   defp apply_phoenix_common_setup(%Project{} = project) do
+    # TODO: Remove me after the Phoenix generator fix releases: https://github.com/phoenixframework/phoenix/pull/4894
+    remove_gettext_compiler()
+
     project
     |> apply_default_common_phoenix_addons()
     |> apply_optional_common_phoenix_addons()
@@ -108,4 +111,8 @@ defmodule NimbleTemplate.Templates.Phoenix.Template do
 
   defp apply_phoenix_variant_setup(%Project{web_project?: true, live_project?: true} = project),
     do: LiveTemplate.apply(project)
+
+  defp remove_gettext_compiler() do
+    Generator.delete_content("mix.exs", "[:gettext] ++ ")
+  end
 end


### PR DESCRIPTION
- Closes #252

## What happened 👀

- Resolve the warning from gettext by removing it from compiler configuration
- The fix can be removed once the Phoenix generator fix releases: https://github.com/phoenixframework/phoenix/pull/4894

## Proof Of Work 📹

- All testings are passed ✅
- `mix.exs` in generated project doesn't have compiler config 

<img width="431" alt="image" src="https://user-images.githubusercontent.com/14077479/190565549-93f207e6-17dd-4e07-b66d-3c0873835999.png">

