### PR TITLE
[gh-253] Do not render the ExVCR in FeatureCase

### DIFF
--- a/lib/nimble_template/addons/addon.ex
+++ b/lib/nimble_template/addons/addon.ex
@@ -16,11 +16,14 @@ defmodule NimbleTemplate.Addons.Addon do
       alias NimbleTemplate.Generator
       alias NimbleTemplate.Hex.Package
       alias NimbleTemplate.Projects.Project
+      alias NimbleTemplate.ProjectHelper
 
       def apply(%Project{} = project, opts \\ %{}) when is_map(opts) do
         Generator.print_log("* applying ", inspect(__MODULE__))
 
-        do_apply(project, opts)
+        project
+        |> do_apply(opts)
+        |> ProjectHelper.append_installed_addon(__MODULE__)
       end
 
       def do_apply(%Project{} = project, opts) when is_map(opts), do: project

--- a/lib/nimble_template/addons/variants/phoenix/web/wallaby.ex
+++ b/lib/nimble_template/addons/variants/phoenix/web/wallaby.ex
@@ -3,6 +3,8 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.Wallaby do
 
   use NimbleTemplate.Addons.Addon
 
+  alias NimbleTemplate.Addons.Phoenix.ExVCR
+
   @impl true
   def do_apply(%Project{} = project, _opts) do
     project
@@ -29,12 +31,17 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.Wallaby do
   end
 
   defp copy_files(
-         %Project{web_module: web_module, base_module: base_module, web_test_path: web_test_path} =
-           project
+         %Project{
+           web_module: web_module,
+           base_module: base_module,
+           web_test_path: web_test_path,
+           installed_addons: installed_addons
+         } = project
        ) do
     binding = [
       web_module: web_module,
-      base_module: base_module
+      base_module: base_module,
+      with_ex_vcr?: ExVCR in installed_addons
     ]
 
     files = [

--- a/lib/nimble_template/helpers/project.ex
+++ b/lib/nimble_template/helpers/project.ex
@@ -1,0 +1,10 @@
+defmodule NimbleTemplate.ProjectHelper do
+  alias NimbleTemplate.Projects.Project
+
+  def append_installed_addon(
+        %Project{installed_addons: existing_installed_addons} = project,
+        new_addon_module_name
+      ) do
+    Map.put(project, :installed_addons, [new_addon_module_name | existing_installed_addons])
+  end
+end

--- a/lib/nimble_template/projects/project.ex
+++ b/lib/nimble_template/projects/project.ex
@@ -23,7 +23,8 @@ defmodule NimbleTemplate.Projects.Project do
             api_project?: false,
             live_project?: false,
             web_project?: false,
-            mix_project?: false
+            mix_project?: false,
+            installed_addons: []
 
   def new(opts \\ %{}) do
     %__MODULE__{
@@ -38,7 +39,8 @@ defmodule NimbleTemplate.Projects.Project do
       web_project?: web_project?(opts),
       live_project?: live_project?(opts),
       mix_project?: mix_project?(opts),
-      elixir_asdf_version: "#{@elixir_version}-otp-#{get_otp_major_version(@erlang_version)}"
+      elixir_asdf_version: "#{@elixir_version}-otp-#{get_otp_major_version(@erlang_version)}",
+      installed_addons: []
     }
   end
 

--- a/priv/templates/nimble_template/.github/workflows/README.md.eex
+++ b/priv/templates/nimble_template/.github/workflows/README.md.eex
@@ -14,7 +14,7 @@ The following workflows are supported.
 
 - A pre-generated [Heroku App](https://devcenter.heroku.com/articles/creating-apps)
 - A Heroku API key. It can be generated under your [Account Settings](https://dashboard.heroku.com/account#api-key)
-- Three Heroku config vars:  
+- Three Heroku config vars:
   - **DATABASE_URL**: It will be created automatically when the [PostgreSQL add-on](https://elements.heroku.com/addons/heroku-postgresql) is added.
   - **PHX_HOST**: if your app name is `acme`, the value of this var is: `acme.herokuapp.com`
   - **HEALTH_PATH**: Health path (eg: "/_health")
@@ -31,7 +31,7 @@ The following workflows are supported.
   socket "/socket", HelloWeb.UserSocket,
     websocket: [timeout: 45_000],
     longpoll: false
-    ...  
+    ...
   ```
 
   otherwise, leaving it set to `false` as default.

--- a/priv/templates/nimble_template/test/support/feature_case.ex.eex
+++ b/priv/templates/nimble_template/test/support/feature_case.ex.eex
@@ -3,7 +3,9 @@ defmodule <%= web_module %>.FeatureCase do
 
   using do
     quote do
+<%= if with_ex_vcr? do %>
       use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+<% end %>
       use Wallaby.Feature
       use Mimic
 

--- a/test/nimble_template/addons/asdf_tool_version_test.exs
+++ b/test/nimble_template/addons/asdf_tool_version_test.exs
@@ -1,6 +1,9 @@
 defmodule NimbleTemplate.Addons.AsdfToolVersionTest do
   use NimbleTemplate.AddonCase, async: false
 
+  alias NimbleTemplate.Addons.AsdfToolVersion
+  alias NimbleTemplate.Projects.Project
+
   describe "#apply/2 with web_project" do
     test "copies the .tool-versions", %{
       project: project,
@@ -16,6 +19,17 @@ defmodule NimbleTemplate.Addons.AsdfToolVersionTest do
                  nodejs 16.15.0
                  """
         end)
+      end)
+    end
+
+    test "appends NimbleTemplate.Addons.AsdfToolVersion to project installed_addons list", %{
+      project: project,
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        %Project{installed_addons: installed_addons} = Addons.AsdfToolVersion.apply(project)
+
+        assert AsdfToolVersion in installed_addons == true
       end)
     end
   end

--- a/test/nimble_template/addons/variants/phoenix/web/wallaby_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/wallaby_test.exs
@@ -18,7 +18,46 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.WallabyTest do
 
                    using do
                      quote do
+
+                       use Wallaby.Feature
+                       use Mimic
+
+                       import NimbleTemplate.Factory
+                       import NimbleTemplateWeb.Gettext
+
+                       alias NimbleTemplate.Repo
+                       alias NimbleTemplateWeb.Endpoint
+                       alias NimbleTemplateWeb.Router.Helpers, as: Routes
+
+                       @moduletag :feature_test
+                     end
+                   end
+                 end
+                 """
+        end)
+      end)
+    end
+
+    test "given the ExVCR addon installed, copies the test/support/feature_case.ex with ExVCR.Mock",
+         %{
+           project: project,
+           test_project_path: test_project_path
+         } do
+      in_test_project(test_project_path, fn ->
+        project = ProjectHelper.append_installed_addon(project, NimbleTemplate.Addons.Phoenix.ExVCR)
+
+        WebAddons.Wallaby.apply(project)
+
+        assert_file("test/support/feature_case.ex", fn file ->
+          assert file =~ """
+                 defmodule NimbleTemplateWeb.FeatureCase do
+                   use ExUnit.CaseTemplate
+
+                   using do
+                     quote do
+
                        use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+
                        use Wallaby.Feature
                        use Mimic
 

--- a/test/support/addon_case.ex
+++ b/test/support/addon_case.ex
@@ -15,6 +15,7 @@ defmodule NimbleTemplate.AddonCase do
       alias NimbleTemplate.Addons.Phoenix, as: PhoenixAddons
       alias NimbleTemplate.Addons.Phoenix.Api, as: ApiAddons
       alias NimbleTemplate.Addons.Phoenix.Web, as: WebAddons
+      alias NimbleTemplate.ProjectHelper
 
       # ATTENTION: File.cd! doesn't support `async: true`, the test will fail randomly in async mode
       # https://elixirforum.com/t/randomly-getting-compilationerror-on-tests/17298/3


### PR DESCRIPTION
https://github.com/nimblehq/elixir-templates/issues/253

## What happened 👀

Do not render the `use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney` in Feature test if the user hasn't choose the ExVCR addon

## Insight 📝

Introduce the `installed_addons` in the Project where we can store the installed addon.

In the Wallaby addon, add a condition to check if the user chooses the ExVCR addon or not by checking the `installed_addons` contains the `NimbleTemplate.Addons.Phoenix.ExVCR` or not.

## Proof Of Work 📹

The test is passed
