### PR TITLE
[#279] Fix: Invalid "Project" struct when initializing Elixir project with custom module name

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -165,7 +165,7 @@
         {Credo.Check.Readability.StrictModuleLayout,
          [
            order:
-             ~w/shortdoc moduledoc behaviour use import alias require module_attribute defstruct callback public_fun private_fun/a,
+             ~w/shortdoc moduledoc behaviour use import alias require module_attribute defstruct type callback public_fun private_fun/a,
            ignore: ~w/callback_impl/a
          ]},
         {Credo.Check.Consistency.MultiAliasImportRequireUse, []},

--- a/lib/nimble_template/projects/project.ex
+++ b/lib/nimble_template/projects/project.ex
@@ -95,7 +95,7 @@ defmodule NimbleTemplate.Projects.Project do
            mix_project?: true
          } = project
        ) do
-    Map.merge(project, %{base_module: base_module(project)})
+    Map.merge(project, %{base_module: base_module()})
   end
 
   defp init_base_module_fields(project) do
@@ -105,7 +105,7 @@ defmodule NimbleTemplate.Projects.Project do
       |> Macro.underscore()
 
     Map.merge(project, %{
-      base_module: base_module(project),
+      base_module: base_module(),
       base_path: "lib/" <> base_module_path,
       base_test_path: "test/" <> base_module_path
     })
@@ -130,7 +130,7 @@ defmodule NimbleTemplate.Projects.Project do
 
   defp maybe_init_web_fields(project), do: project
 
-  defp base_module(%{mix_project?: true}) do
+  defp base_module do
     mix_file_content = File.read!("mix.exs")
 
     ~r/defmodule (.*) do/
@@ -139,6 +139,4 @@ defmodule NimbleTemplate.Projects.Project do
     |> String.split(".")
     |> List.first()
   end
-
-  defp base_module(_project), do: Mix.Phoenix.base()
 end

--- a/lib/nimble_template/projects/project.ex
+++ b/lib/nimble_template/projects/project.ex
@@ -26,15 +26,30 @@ defmodule NimbleTemplate.Projects.Project do
             mix_project?: false,
             installed_addons: []
 
+  @type t :: %__MODULE__{
+          base_module: String.t() | nil,
+          base_path: String.t() | nil,
+          base_test_path: String.t() | nil,
+          otp_app: String.t() | nil,
+          web_module: String.t() | nil,
+          web_path: String.t() | nil,
+          web_test_path: String.t() | nil,
+          alpine_version: String.t(),
+          elixir_version: String.t(),
+          erlang_version: String.t(),
+          node_asdf_version: String.t(),
+          elixir_asdf_version: String.t() | nil,
+          api_project?: boolean(),
+          live_project?: boolean(),
+          web_project?: boolean(),
+          mix_project?: boolean(),
+          installed_addons: list(atom())
+        }
+
+  @spec new(map()) :: __MODULE__.t()
   def new(opts \\ %{}) do
     %__MODULE__{
-      base_module: base_module(),
-      base_path: "lib/" <> Atom.to_string(otp_app()),
-      base_test_path: "test/" <> Atom.to_string(otp_app()),
       otp_app: otp_app(),
-      web_module: base_module() <> "Web",
-      web_path: "lib/" <> Atom.to_string(otp_app()) <> "_web",
-      web_test_path: "test/" <> Atom.to_string(otp_app()) <> "_web",
       api_project?: api_project?(opts),
       web_project?: web_project?(opts),
       live_project?: live_project?(opts),
@@ -42,16 +57,23 @@ defmodule NimbleTemplate.Projects.Project do
       elixir_asdf_version: "#{@elixir_version}-otp-#{get_otp_major_version(@erlang_version)}",
       installed_addons: []
     }
+    |> init_base_module_fields()
+    |> maybe_init_web_fields()
   end
 
+  @spec alpine_version :: String.t()
   def alpine_version, do: @alpine_version
 
+  @spec elixir_version :: String.t()
   def elixir_version, do: @elixir_version
 
+  @spec erlang_version :: String.t()
   def erlang_version, do: @erlang_version
 
+  @spec node_asdf_version :: String.t()
   def node_asdf_version, do: @node_asdf_version
 
+  @spec get_otp_major_version(String.t()) :: String.t()
   def get_otp_major_version(erlang_version) do
     erlang_version
     |> String.split(".")
@@ -68,5 +90,55 @@ defmodule NimbleTemplate.Projects.Project do
 
   defp otp_app(), do: Mix.Phoenix.otp_app()
 
-  defp base_module(), do: Mix.Phoenix.base()
+  defp init_base_module_fields(
+         %{
+           mix_project?: true
+         } = project
+       ) do
+    Map.merge(project, %{base_module: base_module(project)})
+  end
+
+  defp init_base_module_fields(project) do
+    base_module_path =
+      otp_app()
+      |> Atom.to_string()
+      |> Macro.underscore()
+
+    Map.merge(project, %{
+      base_module: base_module(project),
+      base_path: "lib/" <> base_module_path,
+      base_test_path: "test/" <> base_module_path
+    })
+  end
+
+  defp maybe_init_web_fields(
+         %{
+           base_module: base_module,
+           base_path: "lib/" <> base_path,
+           api_project?: api_project?,
+           live_project?: live_project?,
+           web_project?: web_project?
+         } = project
+       )
+       when true in [api_project?, live_project?, web_project?] do
+    Map.merge(project, %{
+      web_module: base_module <> "Web",
+      web_path: "lib/" <> base_path <> "_web",
+      web_test_path: "test/" <> base_path <> "_web"
+    })
+  end
+
+  defp maybe_init_web_fields(project), do: project
+
+  defp base_module(%{mix_project?: true}) do
+    mix_file_content = File.read!("mix.exs")
+
+    ~r/defmodule (.*) do/
+    |> Regex.run(mix_file_content)
+    |> List.last()
+    |> String.split(".")
+    |> List.first()
+  end
+
+  defp base_module(_project), do: Mix.Phoenix.base()
 end

--- a/test/nimble_template/projects/project_test.exs
+++ b/test/nimble_template/projects/project_test.exs
@@ -1,0 +1,101 @@
+defmodule NimbleTemplate.Projects.ProjectTest do
+  use NimbleTemplate.AddonCase, async: false
+
+  alias NimbleTemplate.Projects.Project
+
+  describe "#new/1" do
+    @tag mix_project?: true
+    test "given mix project, returns project without web modules and paths", %{
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        project = Project.new(mix: true)
+
+        assert project.base_module == "NimbleTemplate"
+        assert project.base_path == nil
+        assert project.base_test_path == nil
+        assert project.otp_app == :nimble_template
+        assert project.web_module == nil
+        assert project.web_path == nil
+        assert project.web_test_path == nil
+        assert project.mix_project? == true
+        assert project.web_project? == false
+        assert project.live_project? == false
+        assert project.api_project? == false
+      end)
+    end
+
+    @tag mix_project?: true, opts: "--module=SampleCustomModule"
+    test "given mix project with a custom module name, returns project with valid base module", %{
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        project = Project.new(mix: true)
+
+        assert project.base_module == "SampleCustomModule"
+        assert project.otp_app == :nimble_template
+      end)
+    end
+
+    test "given web project, returns valid project with valid modules and paths", %{
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        project = Project.new(web: true)
+
+        assert project.base_module == "NimbleTemplate"
+        assert project.base_path == "lib/nimble_template"
+        assert project.base_test_path == "test/nimble_template"
+        assert project.otp_app == :nimble_template
+        assert project.web_module == "NimbleTemplateWeb"
+        assert project.web_path == "lib/nimble_template_web"
+        assert project.web_test_path == "test/nimble_template_web"
+        assert project.mix_project? == false
+        assert project.web_project? == true
+        assert project.live_project? == false
+        assert project.api_project? == false
+      end)
+    end
+
+    @tag live_project?: true
+    test "given live project, returns valid project with valid modules and paths", %{
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        project = Project.new(live: true)
+
+        assert project.base_module == "NimbleTemplate"
+        assert project.base_path == "lib/nimble_template"
+        assert project.base_test_path == "test/nimble_template"
+        assert project.otp_app == :nimble_template
+        assert project.web_module == "NimbleTemplateWeb"
+        assert project.web_path == "lib/nimble_template_web"
+        assert project.web_test_path == "test/nimble_template_web"
+        assert project.mix_project? == false
+        assert project.web_project? == true
+        assert project.live_project? == true
+        assert project.api_project? == false
+      end)
+    end
+
+    test "given api project, returns valid project with valid modules and paths", %{
+      test_project_path: test_project_path
+    } do
+      in_test_project(test_project_path, fn ->
+        project = Project.new(api: true)
+
+        assert project.base_module == "NimbleTemplate"
+        assert project.base_path == "lib/nimble_template"
+        assert project.base_test_path == "test/nimble_template"
+        assert project.otp_app == :nimble_template
+        assert project.web_module == "NimbleTemplateWeb"
+        assert project.web_path == "lib/nimble_template_web"
+        assert project.web_test_path == "test/nimble_template_web"
+        assert project.mix_project? == false
+        assert project.web_project? == false
+        assert project.live_project? == false
+        assert project.api_project? == true
+      end)
+    end
+  end
+end

--- a/test/nimble_template/projects/project_test.exs
+++ b/test/nimble_template/projects/project_test.exs
@@ -57,6 +57,28 @@ defmodule NimbleTemplate.Projects.ProjectTest do
       end)
     end
 
+    @tag opts: "--module=SampleCustomModule"
+    test "given web project with a custom module name, returns valid project with valid modules and paths",
+         %{
+           test_project_path: test_project_path
+         } do
+      in_test_project(test_project_path, fn ->
+        project = Project.new(web: true)
+
+        assert project.base_module == "SampleCustomModule"
+        assert project.base_path == "lib/nimble_template"
+        assert project.base_test_path == "test/nimble_template"
+        assert project.otp_app == :nimble_template
+        assert project.web_module == "SampleCustomModuleWeb"
+        assert project.web_path == "lib/nimble_template_web"
+        assert project.web_test_path == "test/nimble_template_web"
+        assert project.mix_project? == false
+        assert project.web_project? == true
+        assert project.live_project? == false
+        assert project.api_project? == false
+      end)
+    end
+
     @tag live_project?: true
     test "given live project, returns valid project with valid modules and paths", %{
       test_project_path: test_project_path
@@ -78,6 +100,28 @@ defmodule NimbleTemplate.Projects.ProjectTest do
       end)
     end
 
+    @tag live_project?: true, opts: "--module=SampleCustomModule"
+    test "given live project with a custom module name, returns valid project with valid modules and paths",
+         %{
+           test_project_path: test_project_path
+         } do
+      in_test_project(test_project_path, fn ->
+        project = Project.new(live: true)
+
+        assert project.base_module == "SampleCustomModule"
+        assert project.base_path == "lib/nimble_template"
+        assert project.base_test_path == "test/nimble_template"
+        assert project.otp_app == :nimble_template
+        assert project.web_module == "SampleCustomModuleWeb"
+        assert project.web_path == "lib/nimble_template_web"
+        assert project.web_test_path == "test/nimble_template_web"
+        assert project.mix_project? == false
+        assert project.web_project? == true
+        assert project.live_project? == true
+        assert project.api_project? == false
+      end)
+    end
+
     test "given api project, returns valid project with valid modules and paths", %{
       test_project_path: test_project_path
     } do
@@ -89,6 +133,28 @@ defmodule NimbleTemplate.Projects.ProjectTest do
         assert project.base_test_path == "test/nimble_template"
         assert project.otp_app == :nimble_template
         assert project.web_module == "NimbleTemplateWeb"
+        assert project.web_path == "lib/nimble_template_web"
+        assert project.web_test_path == "test/nimble_template_web"
+        assert project.mix_project? == false
+        assert project.web_project? == false
+        assert project.live_project? == false
+        assert project.api_project? == true
+      end)
+    end
+
+    @tag api_project?: true, opts: "--module=SampleCustomModule"
+    test "given api project with a custom module name, returns valid project with valid modules and paths",
+         %{
+           test_project_path: test_project_path
+         } do
+      in_test_project(test_project_path, fn ->
+        project = Project.new(api: true)
+
+        assert project.base_module == "SampleCustomModule"
+        assert project.base_path == "lib/nimble_template"
+        assert project.base_test_path == "test/nimble_template"
+        assert project.otp_app == :nimble_template
+        assert project.web_module == "SampleCustomModuleWeb"
         assert project.web_path == "lib/nimble_template_web"
         assert project.web_test_path == "test/nimble_template_web"
         assert project.mix_project? == false

--- a/test/support/addon_case.ex
+++ b/test/support/addon_case.ex
@@ -42,22 +42,22 @@ defmodule NimbleTemplate.AddonCase do
   setup context do
     parent_test_project_path = Path.join(tmp_path(), parent_test_project_path())
     test_project_path = Path.join(parent_test_project_path, "/#{@default_project_name}")
+    opts = Map.get(context, :opts, "")
 
     project =
       cond do
         context[:mix_project?] == true ->
-          opts = Map.get(context, :opts, "")
           create_mix_test_project(test_project_path, opts)
 
           Project.new(mix: true)
 
         context[:live_project?] == true ->
-          create_phoenix_test_project(test_project_path)
+          create_phoenix_test_project(test_project_path, opts)
 
           Project.new(web: true, live: true)
 
         true ->
-          create_phoenix_test_project(test_project_path, "--no-live")
+          create_phoenix_test_project(test_project_path, "'--no-live #{opts}'")
 
           # Set Web Project as default, switch to API in each test case
           # eg: project = %{project | api_project?: true, web_project?: false}
@@ -90,7 +90,7 @@ defmodule NimbleTemplate.AddonCase do
   defp mock_latest_package_version({_package, version}),
     do: expect(Package, :get_latest_version, fn _package -> version end)
 
-  defp create_phoenix_test_project(test_project_path, opts \\ "") do
+  defp create_phoenix_test_project(test_project_path, opts) do
     # N - in response to Fetch and install dependencies?
     Mix.shell().cmd(
       "printf \"N\n\" | make create_phoenix_project PROJECT_DIRECTORY=#{test_project_path} OPTIONS=#{opts} > /dev/null"

--- a/test/support/addon_case.ex
+++ b/test/support/addon_case.ex
@@ -9,6 +9,8 @@ defmodule NimbleTemplate.AddonCase do
   alias NimbleTemplate.Hex.Package
   alias NimbleTemplate.Projects.Project
 
+  @default_project_name "nimble_template"
+
   using do
     quote do
       alias NimbleTemplate.Addons
@@ -39,12 +41,13 @@ defmodule NimbleTemplate.AddonCase do
 
   setup context do
     parent_test_project_path = Path.join(tmp_path(), parent_test_project_path())
-    test_project_path = Path.join(parent_test_project_path, "/nimble_template")
+    test_project_path = Path.join(parent_test_project_path, "/#{@default_project_name}")
 
     project =
       cond do
         context[:mix_project?] == true ->
-          create_mix_test_project(test_project_path)
+          opts = Map.get(context, :opts, "")
+          create_mix_test_project(test_project_path, opts)
 
           Project.new(mix: true)
 
@@ -94,10 +97,10 @@ defmodule NimbleTemplate.AddonCase do
     )
   end
 
-  defp create_mix_test_project(test_project_path) do
+  defp create_mix_test_project(test_project_path, opts) do
     # N - in response to Fetch and install dependencies?
     Mix.shell().cmd(
-      "printf \"N\n\" | make create_mix_project PROJECT_DIRECTORY=#{test_project_path} > /dev/null"
+      "printf \"N\n\" | make create_mix_project PROJECT_DIRECTORY=#{test_project_path} OPTIONS=#{opts} > /dev/null"
     )
   end
 


### PR DESCRIPTION
- Closes #279 

## What happened 👀

- Update the `Project` struct to contain more accurate information about the project structure.
- Add typespecs to the `Project` module

## Insight 📝

- For the mix project, it needs to get the base module from the `mix.exs` file because the mix project does not have access to `Mix.Phoenix.base/0`
- For the mix project, since the generated project does not have the structure same as the web project, so it does not have `base_path` and web-related path and modules. Therefore, all the fields related to that are set to `nil`

## Proof Of Work 📹

| Project type                   | Project structure | `Project` struct |
|--------------------------------|-------------------|------------------|
| Mix project                    |![image](https://user-images.githubusercontent.com/14077479/196619522-4cc75ed7-7cb5-41a3-ac05-e31249cbd236.png)  | ![image](https://user-images.githubusercontent.com/14077479/196620006-4322fd58-1d6b-4985-b924-0cbc687109ab.png)|
| Mix project with custom module |![image](https://user-images.githubusercontent.com/14077479/196619617-aeed9695-5225-4f05-a1e0-a59255c6b7f7.png) | ![image](https://user-images.githubusercontent.com/14077479/196620277-f1704662-653e-4960-b901-6f4c557feec5.png) |
| Web project                    |![image](https://user-images.githubusercontent.com/14077479/196638992-3a7f9041-3e92-4f5e-8d2b-dfbc2584e7fa.png) |![image](https://user-images.githubusercontent.com/14077479/196638842-39c09389-7846-41af-a7f1-4ba5580543b6.png)|
| Web project with custom module |![image](https://user-images.githubusercontent.com/14077479/196639170-14c6680e-a218-4b64-8a4b-4358d5265a8b.png)   |![image](https://user-images.githubusercontent.com/14077479/196638915-70a2c952-e588-4560-a492-339547634720.png)|
