### PR TITLE
Fix Codeowner file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 * @byhbt
 
 # Team Members
-* @andyduong1920 @bterone @hanam1ni @junan @longnd @rosle @topnimble @Nihisil @nvminhtue @liamstevens111
+* @andyduong1920 @bterone @hanam1ni @longnd @rosle @topnimble @Nihisil @nvminhtue @liamstevens111
 
 # Engineering Leads
 CODEOWNERS @nimblehq/engineering-leads


### PR DESCRIPTION
## What happened 👀

As we have a warning in the Codeowners file

![image](https://user-images.githubusercontent.com/11751745/200739267-df53f60e-b979-46fc-a635-801269586ca1.png)


## Insight 📝

Remove `@junan` 👋 


## Proof Of Work 📹

On the file changes tab
