### PR TITLE
[gh-249] Fix infinity loop on Upgrade stack

### DIFF
--- a/lib/nimble_template/helpers/generator.ex
+++ b/lib/nimble_template/helpers/generator.ex
@@ -24,7 +24,12 @@ defmodule NimbleTemplate.Generator do
 
   def rename_file(old_path, new_path), do: File.rename(old_path, new_path)
 
-  def replace_content(file_path, anchor, content, raise_exception \\ true) do
+  def replace_content(file_path, anchor, content, raise_exception \\ true)
+
+  def replace_content(_file_path, anchor, content, _raise_exception) when anchor == content,
+    do: :ok
+
+  def replace_content(file_path, anchor, content, raise_exception) do
     file = Path.join([file_path])
 
     file_content =
@@ -47,6 +52,8 @@ defmodule NimbleTemplate.Generator do
         end
     end
   end
+
+  def replace_content_all(_file_path, anchor, content) when anchor == content, do: :ok
 
   def replace_content_all(file_path, anchor, content) do
     case replace_content(file_path, anchor, content, false) do


### PR DESCRIPTION
https://github.com/nimblehq/elixir-templates/issues/249

## What happened 👀

Solved https://github.com/nimblehq/elixir-templates/issues/249

## Insight 📝

It's because the `anchor is equal to the content`, so that method keep loop forever.

In our case, it's because we have the `-otp-25` in existing Elixir version, and when we upgrade to another `erlang 25` version, we try to `find and replace the -otp-25 by -otp-25`

![image](https://user-images.githubusercontent.com/11751745/200795783-79c93b73-9180-4579-964e-ccf0b0f0f71c.png)

## Proof Of Work 📹

1. Tested on my local
2. Trigger the Workflow https://github.com/nimblehq/elixir-templates/actions/runs/3426992297/jobs/5709447990
3. We have the PR created by that workflow https://github.com/nimblehq/elixir-templates/pull/286
