### PR TITLE
Revisit the  `compile_env` in `router.ex` file

### DIFF
--- a/priv/templates/nimble_template/lib/otp_app_web/helpers/icon_helper.ex.eex
+++ b/priv/templates/nimble_template/lib/otp_app_web/helpers/icon_helper.ex.eex
@@ -8,7 +8,7 @@ defmodule <%= web_module %>.IconHelper do
   alias <%= web_module %>.Router.Helpers, as: Routes
 
   @svg_shape_id_prefix "icon-priv--static--images--icons--"
-  
+
   def icon_tag(conn, icon_file_name, opts \\ []) do
     classes = "icon " <> Keyword.get(opts, :class, "")
 

--- a/priv/templates/nimble_template/lib/otp_app_web/helpers/router_helper.ex.eex
+++ b/priv/templates/nimble_template/lib/otp_app_web/helpers/router_helper.ex.eex
@@ -1,0 +1,3 @@
+defmodule <%= web_module %>.RouterHelper do
+  def health_path, do: Application.get_env(:<%= otp_app %>, <%= web_module %>.Endpoint)[:health_path]
+end

--- a/priv/templates/nimble_template/test/otp_app_web/helpers/router_helper_test.exs.eex
+++ b/priv/templates/nimble_template/test/otp_app_web/helpers/router_helper_test.exs.eex
@@ -1,0 +1,11 @@
+defmodule <%= web_module %>.RouterHelperTest do
+  use <%= web_module %>.ConnCase, async: true
+
+  alias <%= web_module %>.RouterHelper
+
+  describe "health_path/0" do
+    test "returns the `health_path` from the Application configuration" do
+      assert RouterHelper.health_path() == "/_health"
+    end
+  end
+end


### PR DESCRIPTION
## What happened 👀

Revisit the change from https://github.com/nimblehq/elixir-templates/pull/257/files as Top faced an issue with the `health_path` on his IC

## Insight 📝

1/ As `compile_env` is NOT the right use case for that

![image](https://user-images.githubusercontent.com/11751745/201306094-c39a4127-078c-4720-897f-7c62fcac352f.png)

2/ We can't keep using the `get_env!` in the module body as it is deprecated in Elixir 1.14 -> https://hexdocs.pm/elixir/1.14/compatibility-and-deprecations.html

3/ The solution comes from Top -> https://nimble-co.slack.com/archives/C0112R61J3W/p1668409227509499?thread_ts=1668155380.860389&cid=C0112R61J3W

## Proof Of Work 📹

1/ On the file changes tab
2/ The CI is passed
3/ Top's IC can build and run on Production https://github.com/topnimble/elixir-internal-certification/pull/24
