### PR TITLE
Move the gettext check to codebase and codebase.fix

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,5 @@
-# Team Lead
-* @byhbt
-
 # Team Members
-* @andyduong1920 @bterone @hanam1ni @longnd @rosle @topnimble @Nihisil @nvminhtue @liamstevens111
+* @byhbt @andyduong1920 @bterone @hanam1ni @longnd @rosle @topnimble @Nihisil @nvminhtue @liamstevens111
 
 # Engineering Leads
 CODEOWNERS @nimblehq/engineering-leads

--- a/lib/nimble_template/addons/variants/phoenix/gettext.ex
+++ b/lib/nimble_template/addons/variants/phoenix/gettext.ex
@@ -9,14 +9,25 @@ defmodule NimbleTemplate.Addons.Phoenix.Gettext do
   end
 
   defp edit_mix!(%Project{} = project) do
-    Generator.inject_content!(
+    Generator.replace_content!(
       "mix.exs",
       """
-        defp aliases do
-          [
+            codebase: [
       """,
       """
-        "gettext.extract-and-merge": ["gettext.extract --merge --no-fuzzy"],
+            codebase: [
+              "gettext.extract --check-up-to-date",
+      """
+    )
+
+    Generator.replace_content!(
+      "mix.exs",
+      """
+            "codebase.fix": [
+      """,
+      """
+            "codebase.fix": [
+              "gettext.extract --merge --no-fuzzy",
       """
     )
 

--- a/lib/nimble_template/addons/variants/phoenix/web/post_css.ex
+++ b/lib/nimble_template/addons/variants/phoenix/web/post_css.ex
@@ -27,7 +27,8 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.PostCSS do
       """,
       """
         "devDependencies": {
-          "postcss": "8.4.12",
+          "postcss": "8.4.19",
+          "postcss-scss": "4.0.6",
           "postcss-cli": "9.1.0",
           "postcss-load-config": "3.1.4",
           "autoprefixer": "10.4.5",

--- a/priv/templates/nimble_template/.github/workflows/test.yml.eex
+++ b/priv/templates/nimble_template/.github/workflows/test.yml.eex
@@ -148,9 +148,6 @@ jobs:
       - name: Migrate database
         run: mix ecto.migrate
 
-      - name: Ensure that localization files (POs, POTs) are up-to-date.
-        run: mix gettext.extract --check-up-to-date
-
       - name: Run codebase check
         run: mix codebase
 

--- a/test/nimble_template/addons/variants/gettext_test.exs
+++ b/test/nimble_template/addons/variants/gettext_test.exs
@@ -13,7 +13,13 @@ defmodule NimbleTemplate.Addons.Phoenix.GettextTest do
 
         assert_file("mix.exs", fn file ->
           assert file =~ """
-                  "gettext.extract-and-merge": ["gettext.extract --merge --no-fuzzy"],
+                       codebase: [
+                         "gettext.extract --check-up-to-date",
+                 """
+
+          assert file =~ """
+                       "codebase.fix": [
+                         "gettext.extract --merge --no-fuzzy",
                  """
         end)
       end)

--- a/test/nimble_template/addons/variants/phoenix/web/post_css_test.exs
+++ b/test/nimble_template/addons/variants/phoenix/web/post_css_test.exs
@@ -55,7 +55,8 @@ defmodule NimbleTemplate.Addons.Phoenix.Web.PostCSSTest do
         assert_file("assets/package.json", fn file ->
           assert file =~ """
                    "devDependencies": {
-                     "postcss": "8.4.12",
+                     "postcss": "8.4.19",
+                     "postcss-scss": "4.0.6",
                      "postcss-cli": "9.1.0",
                      "postcss-load-config": "3.1.4",
                      "autoprefixer": "10.4.5",


### PR DESCRIPTION
## What happened 👀

A small tweak in the Gettext check

## Insight 📝

We now can move the gettext check into the `codebase` and `codebase.fix` 🎉 so we can have that warning and fix earlier; compared with before, we have to wait on the CI and run an extra command to fix that with `mix gettext.extract-and-merge`

I also fix the syntax in the Codeowner -> raised in https://nimble-co.slack.com/archives/C0112R61J3W/p1669776636999849

NOTE: Need to add the `postcss-scss` to DevDependencies as now the es_lint requires that => https://github.com/stylelint-scss/stylelint-config-standard-scss/issues/2

![image](https://user-images.githubusercontent.com/11751745/204458573-8508c248-591f-48c5-aa6d-802b2d1c765d.png)

## Proof Of Work 📹

On the file changes tab
