### PR TITLE
Excluded MultiAliasImportRequireUse rule on some files

### DIFF
--- a/lib/nimble_template/addons/credo.ex
+++ b/lib/nimble_template/addons/credo.ex
@@ -10,8 +10,13 @@ defmodule NimbleTemplate.Addons.Credo do
     |> edit_files!()
   end
 
-  defp copy_files!(%Project{} = project) do
-    Generator.copy_file!([{:text, ".credo.exs", ".credo.exs"}])
+  defp copy_files!(%Project{web_path: web_path, base_path: base_path} = project) do
+    binding = [
+      base_entry_path: "#{base_path}.ex",
+      web_entry_path: "#{web_path}.ex"
+    ]
+
+    Generator.copy_file!([{:eex, ".credo.exs", ".credo.exs"}], binding)
 
     project
   end

--- a/lib/nimble_template/addons/credo.ex
+++ b/lib/nimble_template/addons/credo.ex
@@ -10,7 +10,15 @@ defmodule NimbleTemplate.Addons.Credo do
     |> edit_files!()
   end
 
-  defp copy_files!(%Project{web_path: web_path, base_path: base_path} = project) do
+  defp copy_files!(%Project{mix_project?: true} = project) do
+    Generator.copy_file!([{:text, ".credo.mix.exs", ".credo.exs"}])
+
+    project
+  end
+
+  defp copy_files!(
+         %Project{web_path: web_path, base_path: base_path, mix_project?: false} = project
+       ) do
     binding = [
       base_entry_path: "#{base_path}.ex",
       web_entry_path: "#{web_path}.ex"

--- a/priv/templates/nimble_template/.credo.exs
+++ b/priv/templates/nimble_template/.credo.exs
@@ -157,12 +157,21 @@
         # Controversial and experimental checks (opt-in, just replace `false` with `[]`)
         #
         {Credo.Check.Readability.StrictModuleLayout,
-         [
-           order:
-             ~w/shortdoc moduledoc behaviour use import alias require module_attribute defstruct callback public_fun private_fun/a,
-           ignore: ~w/callback_impl/a
-         ]},
-        {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
+          [
+            order:
+              ~w/shortdoc moduledoc behaviour use import alias require module_attribute defstruct callback public_fun private_fun/a,
+            ignore: ~w/callback_impl/a
+          ]},
+         {Credo.Check.Consistency.MultiAliasImportRequireUse,
+          files: %{
+            excluded: [
+              "<%= base_entry_path %>",
+              "<%= web_entry_path %>",
+              "test/support/conn_case.ex",
+              "test/support/data_case.ex",
+              "test/support/feature_case.ex"
+            ]
+          }},
         {Credo.Check.Consistency.UnusedVariableNames, false},
         {Credo.Check.Design.DuplicatedCode, files: %{excluded: ["**/*_test.exs"]}},
         {Credo.Check.Readability.AliasAs, false},

--- a/priv/templates/nimble_template/.credo.exs
+++ b/priv/templates/nimble_template/.credo.exs
@@ -162,16 +162,16 @@
               ~w/shortdoc moduledoc behaviour use import alias require module_attribute defstruct callback public_fun private_fun/a,
             ignore: ~w/callback_impl/a
           ]},
-         {Credo.Check.Consistency.MultiAliasImportRequireUse,
-          files: %{
-            excluded: [
-              "<%= base_entry_path %>",
-              "<%= web_entry_path %>",
-              "test/support/conn_case.ex",
-              "test/support/data_case.ex",
-              "test/support/feature_case.ex"
-            ]
-          }},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse,
+        files: %{
+          excluded: [
+            "<%= base_entry_path %>",
+            "<%= web_entry_path %>",
+            "test/support/conn_case.ex",
+            "test/support/data_case.ex",
+            "test/support/feature_case.ex"
+          ]
+        }},
         {Credo.Check.Consistency.UnusedVariableNames, false},
         {Credo.Check.Design.DuplicatedCode, files: %{excluded: ["**/*_test.exs"]}},
         {Credo.Check.Readability.AliasAs, false},

--- a/priv/templates/nimble_template/.credo.mix.exs
+++ b/priv/templates/nimble_template/.credo.mix.exs
@@ -162,16 +162,7 @@
               ~w/shortdoc moduledoc behaviour use import alias require module_attribute defstruct callback public_fun private_fun/a,
             ignore: ~w/callback_impl/a
           ]},
-        {Credo.Check.Consistency.MultiAliasImportRequireUse,
-          files: %{
-            excluded: [
-              "<%= base_entry_path %>",
-              "<%= web_entry_path %>",
-              "test/support/conn_case.ex",
-              "test/support/data_case.ex",
-              "test/support/feature_case.ex"
-            ]
-          }},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
         {Credo.Check.Consistency.UnusedVariableNames, false},
         {Credo.Check.Design.DuplicatedCode, files: %{excluded: ["**/*_test.exs"]}},
         {Credo.Check.Readability.AliasAs, false},

--- a/test/nimble_template/addons/credo_test.exs
+++ b/test/nimble_template/addons/credo_test.exs
@@ -15,15 +15,15 @@ defmodule NimbleTemplate.Addons.CredoTest do
         assert_file(".credo.exs", fn file ->
           assert file =~ """
                  {Credo.Check.Consistency.MultiAliasImportRequireUse,
-                           files: %{
-                             excluded: [
-                               "lib/nimble_template.ex",
-                               "lib/nimble_template_web.ex",
-                               "test/support/conn_case.ex",
-                               "test/support/data_case.ex",
-                               "test/support/feature_case.ex"
-                             ]
-                           }},
+                         files: %{
+                           excluded: [
+                             "lib/nimble_template.ex",
+                             "lib/nimble_template_web.ex",
+                             "test/support/conn_case.ex",
+                             "test/support/data_case.ex",
+                             "test/support/feature_case.ex"
+                           ]
+                         }},
                  """
         end)
       end)

--- a/test/nimble_template/addons/credo_test.exs
+++ b/test/nimble_template/addons/credo_test.exs
@@ -15,15 +15,15 @@ defmodule NimbleTemplate.Addons.CredoTest do
         assert_file(".credo.exs", fn file ->
           assert file =~ """
                  {Credo.Check.Consistency.MultiAliasImportRequireUse,
-                         files: %{
-                           excluded: [
-                             "lib/nimble_template.ex",
-                             "lib/nimble_template_web.ex",
-                             "test/support/conn_case.ex",
-                             "test/support/data_case.ex",
-                             "test/support/feature_case.ex"
-                           ]
-                         }},
+                           files: %{
+                             excluded: [
+                               "lib/nimble_template.ex",
+                               "lib/nimble_template_web.ex",
+                               "test/support/conn_case.ex",
+                               "test/support/data_case.ex",
+                               "test/support/feature_case.ex"
+                             ]
+                           }},
                  """
         end)
       end)
@@ -75,7 +75,11 @@ defmodule NimbleTemplate.Addons.CredoTest do
       in_test_project!(test_project_path, fn ->
         Addons.Credo.apply!(project)
 
-        assert_file(".credo.exs")
+        assert_file(".credo.exs", fn file ->
+          assert file =~ """
+                 {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
+                 """
+        end)
       end)
     end
 

--- a/test/nimble_template/addons/credo_test.exs
+++ b/test/nimble_template/addons/credo_test.exs
@@ -12,7 +12,20 @@ defmodule NimbleTemplate.Addons.CredoTest do
       in_test_project!(test_project_path, fn ->
         Addons.Credo.apply!(project)
 
-        assert_file(".credo.exs")
+        assert_file(".credo.exs", fn file ->
+          assert file =~ """
+                 {Credo.Check.Consistency.MultiAliasImportRequireUse,
+                           files: %{
+                             excluded: [
+                               "lib/nimble_template.ex",
+                               "lib/nimble_template_web.ex",
+                               "test/support/conn_case.ex",
+                               "test/support/data_case.ex",
+                               "test/support/feature_case.ex"
+                             ]
+                           }},
+                 """
+        end)
       end)
     end
 


### PR DESCRIPTION
## What happened 👀

As some developers have to do this manually on their PR 

## Insight 📝

1/ SuT's IC: https://github.com/vnntsu/elixir-ic/pull/31#discussion_r1041697171
2/ Top's IC: https://github.com/topnimble/elixir-internal-certification/blob/4f3c31216fbfad0bef1fc63a365d90c63f52d43c/.credo.exs#L165

## Proof Of Work 📹

On the file changes tab
