### PR TITLE
[gh-307] Fix the invalid disable Credo rule on API variant

### DIFF
--- a/lib/nimble_template/helpers/credo.ex
+++ b/lib/nimble_template/helpers/credo.ex
@@ -7,9 +7,11 @@ defmodule NimbleTemplate.CredoHelper do
 
   @spec disable_rule(String.t(), String.t()) :: :ok | {:error, :failed_to_read_file}
   def disable_rule(file_path, rule) do
-    Generator.prepend_content(file_path, """
-    # credo:disable-for-this-file #{rule}
-    """)
+    if File.exists?(file_path) do
+      Generator.prepend_content(file_path, """
+      # credo:disable-for-this-file #{rule}
+      """)
+    end
   end
 
   @spec disable_do_single_expression_rule(list()) :: :ok | {:error, :failed_to_read_file}
@@ -38,38 +40,39 @@ defmodule NimbleTemplate.CredoHelper do
       ) do
     suppress_credo_warnings_for_base_project(project)
 
-    single_expression_files = [
+    files_contain_single_expression = [
       "#{web_path}/controllers/page_controller.ex",
       "#{web_path}/telemetry.ex",
       "#{web_path}/views/error_view.ex",
       "#{base_path}/release_tasks.ex"
     ]
 
-    disable_do_single_expression_rule(single_expression_files)
+    disable_do_single_expression_rule(files_contain_single_expression)
   end
 
   def suppress_credo_warnings_for_phoenix_api_project(
         %Project{
-          web_test_path: web_test_path,
           base_path: base_path,
-          web_path: web_path
+          web_path: web_path,
+          web_test_path: web_test_path
         } = project
       ) do
     suppress_credo_warnings_for_base_project(project)
 
-    single_module_files = [
+    files_contain_multiple_module = [
       "#{web_test_path}/views/api/error_view_test.exs",
       "#{web_test_path}/params/params_validator_test.exs"
     ]
 
-    disable_single_module_file_rule(single_module_files)
+    disable_single_module_file_rule(files_contain_multiple_module)
 
-    single_expression_files = [
+    files_contain_single_expression = [
+      "#{web_path}/controllers/page_controller.ex",
       "#{base_path}/release_tasks.ex",
       "#{web_path}/telemetry.ex",
       "#{web_path}/views/error_view.ex"
     ]
 
-    disable_do_single_expression_rule(single_expression_files)
+    disable_do_single_expression_rule(files_contain_single_expression)
   end
 end

--- a/lib/nimble_template/helpers/credo.ex
+++ b/lib/nimble_template/helpers/credo.ex
@@ -32,47 +32,44 @@ defmodule NimbleTemplate.CredoHelper do
     disable_do_single_expression_rule(["lib/#{Macro.underscore(base_module)}.ex"])
   end
 
-  def suppress_credo_warnings_for_phoenix_project(
-        %Project{
-          base_path: base_path,
-          web_path: web_path
-        } = project
-      ) do
+  def suppress_credo_warnings_for_phoenix_project(project) do
     suppress_credo_warnings_for_base_project(project)
 
-    files_contain_single_expression = [
-      "#{web_path}/controllers/page_controller.ex",
-      "#{web_path}/telemetry.ex",
-      "#{web_path}/views/error_view.ex",
-      "#{base_path}/release_tasks.ex"
-    ]
-
-    disable_do_single_expression_rule(files_contain_single_expression)
+    project
+    |> get_files_contain_single_expression()
+    |> disable_do_single_expression_rule()
   end
 
-  def suppress_credo_warnings_for_phoenix_api_project(
-        %Project{
-          base_path: base_path,
-          web_path: web_path,
-          web_test_path: web_test_path
-        } = project
-      ) do
+  def suppress_credo_warnings_for_phoenix_api_project(project) do
     suppress_credo_warnings_for_base_project(project)
 
-    files_contain_multiple_module = [
-      "#{web_test_path}/views/api/error_view_test.exs",
-      "#{web_test_path}/params/params_validator_test.exs"
-    ]
+    project
+    |> get_files_contain_multiple_modules()
+    |> disable_single_module_file_rule()
 
-    disable_single_module_file_rule(files_contain_multiple_module)
+    project
+    |> get_files_contain_single_expression()
+    |> disable_do_single_expression_rule()
+  end
 
-    files_contain_single_expression = [
+  defp get_files_contain_single_expression(%Project{
+         base_path: base_path,
+         web_path: web_path
+       }) do
+    [
       "#{web_path}/controllers/page_controller.ex",
       "#{base_path}/release_tasks.ex",
       "#{web_path}/telemetry.ex",
       "#{web_path}/views/error_view.ex"
     ]
+  end
 
-    disable_do_single_expression_rule(files_contain_single_expression)
+  defp get_files_contain_multiple_modules(%Project{
+         web_test_path: web_test_path
+       }) do
+    [
+      "#{web_test_path}/views/api/error_view_test.exs",
+      "#{web_test_path}/params/params_validator_test.exs"
+    ]
   end
 end

--- a/lib/nimble_template/helpers/credo.ex
+++ b/lib/nimble_template/helpers/credo.ex
@@ -5,12 +5,14 @@ defmodule NimbleTemplate.CredoHelper do
   @do_single_expression_rule_name "CompassCredoPlugin.Check.DoSingleExpression"
   @single_module_file_rule_name "CompassCredoPlugin.Check.SingleModuleFile"
 
+  @spec suppress_credo_warnings_for_base_project(Project.t()) :: :ok
   def suppress_credo_warnings_for_base_project(%Project{base_module: base_module}) do
     base_module_path = "lib/#{Macro.underscore(base_module)}.ex"
 
     disable_rule(base_module_path, @do_single_expression_rule_name)
   end
 
+  @spec suppress_credo_warnings_for_phoenix_project(Project.t()) :: :ok
   def suppress_credo_warnings_for_phoenix_project(project) do
     suppress_credo_warnings_for_base_project(project)
 
@@ -19,6 +21,7 @@ defmodule NimbleTemplate.CredoHelper do
     |> disable_rules(@do_single_expression_rule_name)
   end
 
+  @spec suppress_credo_warnings_for_phoenix_api_project(Project.t()) :: :ok
   def suppress_credo_warnings_for_phoenix_api_project(project) do
     suppress_credo_warnings_for_base_project(project)
 

--- a/lib/nimble_template/helpers/credo.ex
+++ b/lib/nimble_template/helpers/credo.ex
@@ -1,10 +1,75 @@
 defmodule NimbleTemplate.CredoHelper do
   alias NimbleTemplate.Generator
+  alias NimbleTemplate.Projects.Project
+
+  @do_single_expression_rule_name "CompassCredoPlugin.Check.DoSingleExpression"
+  @single_module_file_rule_name "CompassCredoPlugin.Check.SingleModuleFile"
 
   @spec disable_rule(String.t(), String.t()) :: :ok | {:error, :failed_to_read_file}
   def disable_rule(file_path, rule) do
     Generator.prepend_content(file_path, """
     # credo:disable-for-this-file #{rule}
     """)
+  end
+
+  @spec disable_do_single_expression_rule(list()) :: :ok | {:error, :failed_to_read_file}
+  def disable_do_single_expression_rule(file_paths) do
+    Enum.each(file_paths, fn file_path ->
+      disable_rule(file_path, @do_single_expression_rule_name)
+    end)
+  end
+
+  @spec disable_single_module_file_rule(list()) :: :ok | {:error, :failed_to_read_file}
+  def disable_single_module_file_rule(file_paths) do
+    Enum.each(file_paths, fn file_path ->
+      disable_rule(file_path, @single_module_file_rule_name)
+    end)
+  end
+
+  def suppress_credo_warnings_for_base_project(%Project{base_module: base_module}) do
+    disable_do_single_expression_rule(["lib/#{Macro.underscore(base_module)}.ex"])
+  end
+
+  def suppress_credo_warnings_for_phoenix_project(
+        %Project{
+          base_path: base_path,
+          web_path: web_path
+        } = project
+      ) do
+    suppress_credo_warnings_for_base_project(project)
+
+    single_expression_files = [
+      "#{web_path}/controllers/page_controller.ex",
+      "#{web_path}/telemetry.ex",
+      "#{web_path}/views/error_view.ex",
+      "#{base_path}/release_tasks.ex"
+    ]
+
+    disable_do_single_expression_rule(single_expression_files)
+  end
+
+  def suppress_credo_warnings_for_phoenix_api_project(
+        %Project{
+          web_test_path: web_test_path,
+          base_path: base_path,
+          web_path: web_path
+        } = project
+      ) do
+    suppress_credo_warnings_for_base_project(project)
+
+    single_module_files = [
+      "#{web_test_path}/views/api/error_view_test.exs",
+      "#{web_test_path}/params/params_validator_test.exs"
+    ]
+
+    disable_single_module_file_rule(single_module_files)
+
+    single_expression_files = [
+      "#{base_path}/release_tasks.ex",
+      "#{web_path}/telemetry.ex",
+      "#{web_path}/views/error_view.ex"
+    ]
+
+    disable_do_single_expression_rule(single_expression_files)
   end
 end

--- a/lib/nimble_template/helpers/credo.ex
+++ b/lib/nimble_template/helpers/credo.ex
@@ -5,14 +5,17 @@ defmodule NimbleTemplate.CredoHelper do
   @do_single_expression_rule_name "CompassCredoPlugin.Check.DoSingleExpression"
   @single_module_file_rule_name "CompassCredoPlugin.Check.SingleModuleFile"
 
-  def suppress_credo_warnings_for_base_project(%Project{base_module: base_module}),
-    do: disable_rules(["lib/#{Macro.underscore(base_module)}.ex"], @do_single_expression_rule_name)
+  def suppress_credo_warnings_for_base_project(%Project{base_module: base_module}) do
+    base_module_path = "lib/#{Macro.underscore(base_module)}.ex"
+
+    disable_rule(base_module_path, @do_single_expression_rule_name)
+  end
 
   def suppress_credo_warnings_for_phoenix_project(project) do
     suppress_credo_warnings_for_base_project(project)
 
     project
-    |> get_files_contain_single_expression()
+    |> get_files_containing_single_expression()
     |> disable_rules(@do_single_expression_rule_name)
   end
 
@@ -20,27 +23,27 @@ defmodule NimbleTemplate.CredoHelper do
     suppress_credo_warnings_for_base_project(project)
 
     project
-    |> get_files_contain_multiple_modules()
+    |> get_files_containing_multiple_modules()
     |> disable_rules(@single_module_file_rule_name)
 
     project
-    |> get_files_contain_single_expression()
+    |> get_files_containing_single_expression()
     |> disable_rules(@do_single_expression_rule_name)
   end
 
-  defp get_files_contain_single_expression(%Project{
+  defp get_files_containing_single_expression(%Project{
          base_path: base_path,
          web_path: web_path
        }) do
     [
-      "#{web_path}/controllers/page_controller.ex",
       "#{base_path}/release_tasks.ex",
+      "#{web_path}/controllers/page_controller.ex",
       "#{web_path}/telemetry.ex",
       "#{web_path}/views/error_view.ex"
     ]
   end
 
-  defp get_files_contain_multiple_modules(%Project{
+  defp get_files_containing_multiple_modules(%Project{
          web_test_path: web_test_path
        }) do
     [

--- a/lib/nimble_template/templates/template.ex
+++ b/lib/nimble_template/templates/template.ex
@@ -2,9 +2,9 @@ defmodule NimbleTemplate.Templates.Template do
   @moduledoc false
 
   import NimbleTemplate.DependencyHelper
+  import NimbleTemplate.CredoHelper
 
   alias NimbleTemplate.Addons.ExUnit
-  alias NimbleTemplate.CredoHelper
   alias NimbleTemplate.Projects.Project
   alias NimbleTemplate.Templates.Mix.Template, as: MixTemplate
   alias NimbleTemplate.Templates.Phoenix.Template, as: PhoenixTemplate
@@ -31,80 +31,33 @@ defmodule NimbleTemplate.Templates.Template do
 
   defp post_apply!(%Project{mix_project?: true} = project) do
     order_dependencies!()
-    fetch_and_install_elixir_dependencies()
+    install_elixir_dependencies()
     suppress_credo_warnings_for_base_project(project)
     format_codebase()
   end
 
   defp post_apply!(%Project{api_project?: true} = project) do
     order_dependencies!()
-    fetch_and_install_elixir_dependencies()
+    install_elixir_dependencies()
     suppress_credo_warnings_for_phoenix_api_project(project)
     format_codebase()
   end
 
   defp post_apply!(%Project{web_project?: true} = project) do
     order_dependencies!()
-    fetch_and_install_elixir_dependencies()
-    fetch_and_install_node_dependencies()
+    install_elixir_dependencies()
+    install_node_dependencies()
     suppress_credo_warnings_for_phoenix_project(project)
     format_codebase()
   end
 
-  defp fetch_and_install_elixir_dependencies() do
+  defp install_elixir_dependencies() do
     Mix.shell().cmd("MIX_ENV=dev mix do deps.get, deps.compile")
     Mix.shell().cmd("MIX_ENV=test mix do deps.get, deps.compile")
   end
 
-  defp fetch_and_install_node_dependencies() do
+  defp install_node_dependencies() do
     Mix.shell().cmd("npm install --prefix assets")
-  end
-
-  defp suppress_credo_warnings_for_base_project(%Project{base_module: base_module}) do
-    CredoHelper.disable_rule(
-      "lib/#{Macro.underscore(base_module)}.ex",
-      "CompassCredoPlugin.Check.DoSingleExpression"
-    )
-  end
-
-  defp suppress_credo_warnings_for_phoenix_project(
-         %Project{
-           base_path: base_path,
-           web_path: web_path
-         } = project
-       ) do
-    suppress_credo_warnings_for_base_project(project)
-
-    Enum.each(
-      [
-        "#{web_path}/controllers/page_controller.ex",
-        "#{web_path}/telemetry.ex",
-        "#{web_path}/views/error_view.ex",
-        "#{base_path}/release_tasks.ex"
-      ],
-      fn file_path ->
-        CredoHelper.disable_rule(file_path, "CompassCredoPlugin.Check.DoSingleExpression")
-      end
-    )
-  end
-
-  defp suppress_credo_warnings_for_phoenix_api_project(
-         %Project{
-           web_test_path: web_test_path
-         } = project
-       ) do
-    suppress_credo_warnings_for_base_project(project)
-    suppress_credo_warnings_for_phoenix_project(project)
-
-    Enum.each(
-      [
-        "#{web_test_path}/views/api/error_view_test.exs",
-        "#{web_test_path}/params/params_validator_test.exs"
-      ],
-      fn file_path ->
-        CredoHelper.disable_rule(file_path, "CompassCredoPlugin.Check.SingleModuleFile")
-      end
-    )
   end
 
   defp format_codebase() do

--- a/lib/nimble_template/templates/template.ex
+++ b/lib/nimble_template/templates/template.ex
@@ -1,9 +1,8 @@
 defmodule NimbleTemplate.Templates.Template do
   @moduledoc false
 
-  import NimbleTemplate.{CredoHelper, DependencyHelper}
-
   alias NimbleTemplate.Addons.ExUnit
+  alias NimbleTemplate.{CredoHelper, DependencyHelper}
   alias NimbleTemplate.Projects.Project
   alias NimbleTemplate.Templates.Mix.Template, as: MixTemplate
   alias NimbleTemplate.Templates.Phoenix.Template, as: PhoenixTemplate
@@ -29,24 +28,24 @@ defmodule NimbleTemplate.Templates.Template do
   end
 
   defp post_apply!(%Project{mix_project?: true} = project) do
-    order_dependencies!()
+    DependencyHelper.order_dependencies!()
     install_elixir_dependencies()
-    suppress_credo_warnings_for_base_project(project)
+    CredoHelper.suppress_credo_warnings_for_base_project(project)
     format_codebase()
   end
 
   defp post_apply!(%Project{api_project?: true} = project) do
-    order_dependencies!()
+    DependencyHelper.order_dependencies!()
     install_elixir_dependencies()
-    suppress_credo_warnings_for_phoenix_api_project(project)
+    CredoHelper.suppress_credo_warnings_for_phoenix_api_project(project)
     format_codebase()
   end
 
   defp post_apply!(%Project{web_project?: true} = project) do
-    order_dependencies!()
+    DependencyHelper.order_dependencies!()
     install_elixir_dependencies()
     install_node_dependencies()
-    suppress_credo_warnings_for_phoenix_project(project)
+    CredoHelper.suppress_credo_warnings_for_phoenix_project(project)
     format_codebase()
   end
 

--- a/lib/nimble_template/templates/template.ex
+++ b/lib/nimble_template/templates/template.ex
@@ -1,8 +1,7 @@
 defmodule NimbleTemplate.Templates.Template do
   @moduledoc false
 
-  import NimbleTemplate.DependencyHelper
-  import NimbleTemplate.CredoHelper
+  import NimbleTemplate.{CredoHelper, DependencyHelper}
 
   alias NimbleTemplate.Addons.ExUnit
   alias NimbleTemplate.Projects.Project

--- a/lib/nimble_template/templates/template.ex
+++ b/lib/nimble_template/templates/template.ex
@@ -55,11 +55,7 @@ defmodule NimbleTemplate.Templates.Template do
     Mix.shell().cmd("MIX_ENV=test mix do deps.get, deps.compile")
   end
 
-  defp install_node_dependencies() do
-    Mix.shell().cmd("npm install --prefix assets")
-  end
+  defp install_node_dependencies(), do: Mix.shell().cmd("npm install --prefix assets")
 
-  defp format_codebase() do
-    Mix.shell().cmd("mix codebase.fix")
-  end
+  defp format_codebase(), do: Mix.shell().cmd("mix codebase.fix")
 end

--- a/lib/nimble_template/templates/variants/phoenix/template.ex
+++ b/lib/nimble_template/templates/variants/phoenix/template.ex
@@ -44,7 +44,6 @@ defmodule NimbleTemplate.Templates.Phoenix.Template do
     end
   end
 
-  # credo:disable-for-next-line Credo.Check.Refactor.ABCSize
   defp apply_phoenix_common_setup(%Project{} = project) do
     # TODO: Remove me after the Phoenix generator fix releases: https://github.com/phoenixframework/phoenix/pull/4894
     remove_mix_compiler_config!()

--- a/test/nimble_template/helpers/credo_test.exs
+++ b/test/nimble_template/helpers/credo_test.exs
@@ -9,22 +9,43 @@ defmodule NimbleTemplate.CredoHelperTest do
       project: project
     } do
       in_test_project!(test_project_path, fn ->
-        sample_module_file = "lib/nimble_template.ex"
-
-        File.write!(sample_module_file, """
-        defmodule SampleModule do
-          def foo, do: "bar"
-        end
-        """)
-
         CredoHelper.suppress_credo_warnings_for_base_project(project)
 
-        assert_file(sample_module_file, fn file ->
-          assert file == """
+        assert_file("#{test_project_path}/lib/nimble_template.ex", fn file ->
+          assert file =~ """
                  # credo:disable-for-this-file CompassCredoPlugin.Check.DoSingleExpression
-                 defmodule SampleModule do
-                   def foo, do: "bar"
-                 end
+                 """
+        end)
+      end)
+    end
+  end
+
+  describe "suppress_credo_warnings_for_phoenix_project/1" do
+    test "prepends credo rule disabling in the given file", %{
+      test_project_path: test_project_path,
+      project: project
+    } do
+      in_test_project!(test_project_path, fn ->
+        CredoHelper.suppress_credo_warnings_for_phoenix_project(project)
+
+        assert_file(
+          "#{test_project_path}/lib/nimble_template_web/controllers/page_controller.ex",
+          fn file ->
+            assert file =~ """
+                   # credo:disable-for-this-file CompassCredoPlugin.Check.DoSingleExpression
+                   """
+          end
+        )
+
+        assert_file("#{test_project_path}/lib/nimble_template_web/telemetry.ex", fn file ->
+          assert file =~ """
+                 # credo:disable-for-this-file CompassCredoPlugin.Check.DoSingleExpression
+                 """
+        end)
+
+        assert_file("#{test_project_path}/lib/nimble_template_web/views/error_view.ex", fn file ->
+          assert file =~ """
+                 # credo:disable-for-this-file CompassCredoPlugin.Check.DoSingleExpression
                  """
         end)
       end)

--- a/test/nimble_template/helpers/credo_test.exs
+++ b/test/nimble_template/helpers/credo_test.exs
@@ -3,22 +3,25 @@ defmodule NimbleTemplate.CredoHelperTest do
 
   alias NimbleTemplate.CredoHelper
 
-  describe "disable_rule/2" do
+  describe "suppress_credo_warnings_for_base_project/1" do
     test "prepends credo rule disabling in the given file", %{
-      test_project_path: test_project_path
+      test_project_path: test_project_path,
+      project: project
     } do
       in_test_project!(test_project_path, fn ->
-        File.write!("sample_module.exs", """
+        sample_module_file = "lib/nimble_template.ex"
+
+        File.write!(sample_module_file, """
         defmodule SampleModule do
           def foo, do: "bar"
         end
         """)
 
-        CredoHelper.disable_rule("sample_module.exs", "Credo.Check.Readability.RedundantBlankLines")
+        CredoHelper.suppress_credo_warnings_for_base_project(project)
 
-        assert_file("sample_module.exs", fn file ->
+        assert_file(sample_module_file, fn file ->
           assert file == """
-                 # credo:disable-for-this-file Credo.Check.Readability.RedundantBlankLines
+                 # credo:disable-for-this-file CompassCredoPlugin.Check.DoSingleExpression
                  defmodule SampleModule do
                    def foo, do: "bar"
                  end


### PR DESCRIPTION
Resolves https://github.com/nimblehq/elixir-templates/issues/307

## What happened 👀

- [x] Extract the disable Credo rule into the credo helper.
- [x] Add checking `file_exist?/1` in case a new project is created with `--no-html`, the `page_controller` does not exist there.
- [x] Rename  fetch_and_install_* => `install_*` to make it cleaner.
- [x] Refactor the `template.ex`: using `alias` to reference to the helper methods instead of `import`

## Insight 📝

n/a

## Proof Of Work 📹

The test should pass.
