### PR TITLE
Replace the cancel previous run by the concurrency

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Team Members
-* @byhbt @andyduong1920 @bterone @hanam1ni @longnd @rosle @topnimble @Nihisil @nvminhtue @liamstevens111
+* @byhbt @andyduong1920 @bterone @hanam1ni @longnd @rosle @topnimble @Nihisil @nvminhtue @liamstevens111 @vnntsu
 
 # Engineering Leads
 CODEOWNERS @nimblehq/engineering-leads

--- a/.github/workflows/apply_api_variant.yml
+++ b/.github/workflows/apply_api_variant.yml
@@ -2,6 +2,10 @@ name: Apply API variant
 
 on: push
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   standard_api_project:
     name: Test on a Standard API project

--- a/.github/workflows/apply_live_variant.yml
+++ b/.github/workflows/apply_live_variant.yml
@@ -2,6 +2,10 @@ name: Apply Live variant
 
 on: push
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   standard_project:
     name: Test on a Standard Live project

--- a/.github/workflows/apply_mix_variant.yml
+++ b/.github/workflows/apply_mix_variant.yml
@@ -2,6 +2,10 @@ name: Apply Mix variant
 
 on: push
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   standard_mix_project:
     name: Test on a Standard Mix project

--- a/.github/workflows/apply_web_variant.yml
+++ b/.github/workflows/apply_web_variant.yml
@@ -2,6 +2,10 @@ name: Apply Web variant
 
 on: push
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   standard_project:
     name: Test on a Standard Web project

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       newVersion:
-        description: "New version"
+        description: "Z New version"
         required: true
         type: string
 

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       newVersion:
-        description: "Z New version"
+        description: "New version"
         required: true
         type: string
 

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -12,17 +12,16 @@ env:
   PHOENIX_VERSION: 1.6.11
   MIX_ENV: test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release_version_test:
     name: Bump version
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       newVersion:
-        description: "New version"
+        description: "TEMP New version"
         required: true
         type: string
 

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       newVersion:
-        description: "TEMP New version"
+        description: "New version"
         required: true
         type: string
 

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       newVersion:
-        description: "Create New version"
+        description: "New version"
         required: true
         type: string
 

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       newVersion:
-        description: "New version"
+        description: "Create New version"
         required: true
         type: string
 

--- a/.github/workflows/publish_to_hex_pm.yml
+++ b/.github/workflows/publish_to_hex_pm.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     name: Publish hex package
@@ -13,11 +17,6 @@ jobs:
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/reusable_mix_project.yml
+++ b/.github/workflows/reusable_mix_project.yml
@@ -11,17 +11,14 @@ env:
   BASE_PROJECT_DIRECTORY: sample_project
   MIX_ENV: dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit_test:
     name: Unit test
     runs-on: ubuntu-latest
-
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/reusable_mix_project.yml
+++ b/.github/workflows/reusable_mix_project.yml
@@ -19,6 +19,8 @@ jobs:
   unit_test:
     name: Unit test
     runs-on: ubuntu-latest
+
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/reusable_mix_project.yml
+++ b/.github/workflows/reusable_mix_project.yml
@@ -11,10 +11,6 @@ env:
   BASE_PROJECT_DIRECTORY: sample_project
   MIX_ENV: dev
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   unit_test:
     name: Unit test

--- a/.github/workflows/reusable_phoenix_project.yml
+++ b/.github/workflows/reusable_phoenix_project.yml
@@ -16,6 +16,10 @@ env:
   DB_HOST: localhost
   MIX_ENV: dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit_test:
     name: Unit test
@@ -33,11 +37,6 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/reusable_phoenix_project.yml
+++ b/.github/workflows/reusable_phoenix_project.yml
@@ -16,10 +16,6 @@ env:
   DB_HOST: localhost
   MIX_ENV: dev
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   unit_test:
     name: Unit test

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -6,17 +6,16 @@ env:
   PHOENIX_VERSION: 1.6.11
   MIX_ENV: test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   install_and_compile_dependencies:
     name: Install and Compile Dependencies
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -64,11 +63,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -122,11 +116,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/upgrade_stack.yml
+++ b/.github/workflows/upgrade_stack.yml
@@ -27,17 +27,16 @@ env:
   PHOENIX_VERSION: 1.6.11
   MIX_ENV: test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release_version_test:
     name: Upgrade Stack
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/verify_release_version.yml
+++ b/.github/workflows/verify_release_version.yml
@@ -9,17 +9,16 @@ env:
   PHOENIX_VERSION: 1.6.11
   MIX_ENV: test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release_version_test:
     name: Verify the Release version
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/priv/templates/nimble_template/.github/workflows/deploy_heroku.yml
+++ b/priv/templates/nimble_template/.github/workflows/deploy_heroku.yml
@@ -17,7 +17,7 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' || github.ref != 'refs/heads/develop' }}
 
 jobs:
   deploy:

--- a/priv/templates/nimble_template/.github/workflows/deploy_heroku.yml
+++ b/priv/templates/nimble_template/.github/workflows/deploy_heroku.yml
@@ -15,17 +15,16 @@ env:
   HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
   HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   deploy:
     name: Deploy to Heroku
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/priv/templates/nimble_template/.github/workflows/test.yml.eex
+++ b/priv/templates/nimble_template/.github/workflows/test.yml.eex
@@ -6,6 +6,10 @@ env:
   MIX_ENV: test
   DB_HOST: localhost
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   install_and_compile_dependencies:
     name: Install and Compile Dependencies
@@ -13,11 +17,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/priv/templates/nimble_template/.github/workflows/test.yml.mix.eex
+++ b/priv/templates/nimble_template/.github/workflows/test.yml.mix.eex
@@ -5,6 +5,10 @@ on: pull_request
 env:
   MIX_ENV: test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   install_and_compile_dependencies:
     name: Install and Compile Dependencies
@@ -12,11 +16,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION

## What happened 👀

- Replace the step `Cancel Previous Runs` in all the workflow. Replace it by the `concurrency` group
- Add new team member to the CODEOWNER

## Insight 📝

As the suggestion from the creator of `Cancel Previous Runs`:

<img width="696" alt="image" src="https://user-images.githubusercontent.com/948856/228105925-2e3e7f73-148c-4b87-abf2-a3dec08ebedc.png">

Reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

## Proof Of Work 📹

![image](https://user-images.githubusercontent.com/948856/230711570-10c15c72-987c-4b19-899a-42bef6b80bb9.png)

